### PR TITLE
CI: run workflow on all branches, not just main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -315,6 +315,7 @@ jobs:
 
   deploy-docs:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.repository == 'asfernandes/fb-cpp'
     needs:
       - clang-format-check
       - build-linux


### PR DESCRIPTION
Allow contributors working on forks to get CI feedback on feature branches.