### PR TITLE
Expose descriptor metadata: name, relation, alias, owner, charSetId, subType

### DIFF
--- a/src/fb-cpp/Descriptor.h
+++ b/src/fb-cpp/Descriptor.h
@@ -26,6 +26,7 @@
 #define FBCPP_DESCRIPTOR_H
 
 #include "fb-api.h"
+#include <string>
 
 
 ///
@@ -279,7 +280,36 @@ namespace fbcpp
 		/// Indicates whether the column or parameter can contain null values.
 		///
 		bool isNullable;
-		// FIXME: more things
+
+		///
+		/// Column or parameter name.
+		///
+		std::string name;
+
+		///
+		/// Table or relation this column belongs to (empty for expressions).
+		///
+		std::string relation;
+
+		///
+		/// Column alias as it appears in the query's SELECT list.
+		///
+		std::string alias;
+
+		///
+		/// Owner of the relation (empty for expressions).
+		///
+		std::string owner;
+
+		///
+		/// Character set ID for string and BLOB columns.
+		///
+		unsigned charSetId;
+
+		///
+		/// Sub-type (BLOB sub-type or numeric sub-type).
+		///
+		int subType;
 	};
 }  // namespace fbcpp
 

--- a/src/fb-cpp/Statement.cpp
+++ b/src/fb-cpp/Statement.cpp
@@ -108,6 +108,12 @@ Statement::Statement(
 				.offset = 0,
 				.nullOffset = 0,
 				.isNullable = static_cast<bool>(metadata->isNullable(&statusWrapper, index)),
+				.name = metadata->getField(&statusWrapper, index),
+				.relation = metadata->getRelation(&statusWrapper, index),
+				.alias = metadata->getAlias(&statusWrapper, index),
+				.owner = metadata->getOwner(&statusWrapper, index),
+				.charSetId = metadata->getCharSet(&statusWrapper, index),
+				.subType = metadata->getSubType(&statusWrapper, index),
 			};
 
 			switch (descriptor.originalType)


### PR DESCRIPTION
## Summary

Add six new metadata fields to the `Descriptor` struct, populated from `IMessageMetadata` during statement preparation. This resolves the `// FIXME: more things` placeholder and provides ODBC-level metadata access without requiring consumers to use the low-level Firebird API directly.

## Changes

**`Descriptor.h`** — Six new fields added to `Descriptor`:

| Field | Source (`IMessageMetadata`) | Description |
|---|---|---|
| `name` | `getField()` | Column or parameter name |
| `relation` | `getRelation()` | Table/relation name (empty for expressions) |
| `alias` | `getAlias()` | Column alias from the SELECT list |
| `owner` | `getOwner()` | Relation owner (empty for expressions) |
| `charSetId` | `getCharSet()` | Character set ID |
| `subType` | `getSubType()` | BLOB sub-type or numeric sub-type |

**`Statement.cpp`** — Fields populated in the `processMetadata` lambda alongside existing descriptor initialization.

**`test/Statement.cpp`** — New `descriptorMetadataFields` test case that:
- Creates a table with integer, varchar, numeric, and text blob columns
- Queries with aliases and verifies `name`, `alias`, `relation`, `subType` on output descriptors
- Verifies input parameter descriptors have empty names/relations/aliases

## Notes

- Non-breaking, additive change — all existing code is unaffected
- Field naming follows maintainer's request from #37: `name` (not `field`) and `charSetId` (not `charSet`)
- Raw `IMessageMetadata` accessors (`getInputMetadata()` / `getOutputMetadata()`) remain available for advanced use cases

Closes #37