### PR TITLE
Fix vcpkg cache paths for Linux and macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,10 +53,10 @@ jobs:
             vcpkg/downloads
             vcpkg/buildtrees
             vcpkg/packages
-            build/Release/vcpkg_installed
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+            build/vcpkg_installed
+          key: ${{ runner.os }}-vcpkg-v3-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           restore-keys: |
-            ${{ runner.os }}-vcpkg-
+            ${{ runner.os }}-vcpkg-v3-
 
       - name: Install system dependencies
         run: |
@@ -158,9 +158,9 @@ jobs:
             vcpkg/buildtrees
             vcpkg/packages
             build/vcpkg_installed
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          key: ${{ runner.os }}-vcpkg-v3-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           restore-keys: |
-            ${{ runner.os }}-vcpkg-
+            ${{ runner.os }}-vcpkg-v3-
 
       - name: Install Firebird
         shell: cmd
@@ -247,10 +247,10 @@ jobs:
             vcpkg/downloads
             vcpkg/buildtrees
             vcpkg/packages
-            build/Release/vcpkg_installed
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+            build/vcpkg_installed
+          key: ${{ runner.os }}-vcpkg-v3-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
           restore-keys: |
-            ${{ runner.os }}-vcpkg-
+            ${{ runner.os }}-vcpkg-v3-
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,6 +42,18 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Cache vcpkg artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            vcpkg/downloads
+            vcpkg/buildtrees
+            vcpkg/packages
+            build/vcpkg_installed
+          key: ${{ runner.os }}-vcpkg-v3-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-v3-
+
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -129,6 +141,18 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Cache vcpkg artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            vcpkg/downloads
+            vcpkg/buildtrees
+            vcpkg/packages
+            build/vcpkg_installed
+          key: ${{ runner.os }}-vcpkg-v3-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-v3-
+
       - name: Install Firebird
         shell: cmd
         run: |
@@ -208,6 +232,18 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
+      - name: Cache vcpkg artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            vcpkg/downloads
+            vcpkg/buildtrees
+            vcpkg/packages
+            build/vcpkg_installed
+          key: ${{ runner.os }}-vcpkg-v3-${{ hashFiles('vcpkg.json', 'vcpkg-configuration.json') }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-v3-
 
       - name: Install system dependencies
         run: |


### PR DESCRIPTION
## Problem

The vcpkg cache paths in `main.yml` for Linux and macOS were set to `build/Release/vcpkg_installed`, but `CMakePresets.json` sets `VCPKG_INSTALLED_DIR` to `build/vcpkg_installed` (shared across all presets). This path mismatch meant the cache was saving/restoring the wrong directory, causing vcpkg to rebuild all ~60 packages from source on every run (~9 min).

Windows was already using the correct path (`build/vcpkg_installed`).

Additionally, `pull-request.yml` was missing vcpkg cache steps entirely for all three platforms.

## Changes

1. Fixed Linux and macOS cache paths from `build/Release/vcpkg_installed` to `build/vcpkg_installed` in `main.yml`
2. Added missing vcpkg cache steps to `pull-request.yml` for all three platforms (Linux, Windows, macOS)
3. Bumped cache key version to `v3` to invalidate stale entries

## Timing measurements

### "Configure CMake" step (where vcpkg install runs)

| Platform | Before (broken cache) | After (cache hit) | Improvement |
|----------|----------------------|-------------------|-------------|
| Linux    | 9m 40s               | 18s               | **-9m 22s (97%)** |
| macOS    | 8m 22s               | 1m 53s            | **-6m 29s (78%)** |
| Windows  | 19m 11s              | 42s               | **-18m 29s (96%)** |

### Total job time

| Platform | Before (broken cache) | After (cache hit) | Improvement |
|----------|----------------------|-------------------|-------------|
| Linux    | 11m 47s              | 2m 14s            | **-9m 33s (81%)** |
| macOS    | 9m 56s               | 4m 00s            | **-5m 56s (60%)** |
| Windows  | 23m 19s              | 5m 07s            | **-18m 12s (78%)** |

### Workflow runs

- Baseline (main, broken cache): https://github.com/fdcastel/fb-cpp/actions/runs/22879333936
- Cold cache (first run): https://github.com/fdcastel/fb-cpp/actions/runs/22921487352
- Warm cache (second run): https://github.com/fdcastel/fb-cpp/actions/runs/22922934856
