### PR TITLE
Add disconnected RowSet class with typed Row access

### DIFF
--- a/src/fb-cpp/Attachment.cpp
+++ b/src/fb-cpp/Attachment.cpp
@@ -37,7 +37,7 @@ Attachment::Attachment(Client& client, const std::string& uri, const AttachmentO
 
 	StatusWrapper statusWrapper{client};
 
-	auto dpbBuilder = fbUnique(master->getUtilInterface()->getXpbBuilder(&statusWrapper, fb::IXpbBuilder::DPB,
+	auto dpbBuilder = fbUnique(client.getUtil()->getXpbBuilder(&statusWrapper, fb::IXpbBuilder::DPB,
 		reinterpret_cast<const std::uint8_t*>(options.getDpb().data()),
 		static_cast<unsigned>(options.getDpb().size())));
 

--- a/src/fb-cpp/Attachment.cpp
+++ b/src/fb-cpp/Attachment.cpp
@@ -35,8 +35,7 @@ Attachment::Attachment(Client& client, const std::string& uri, const AttachmentO
 {
 	const auto master = client.getMaster();
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	auto dpbBuilder = fbUnique(master->getUtilInterface()->getXpbBuilder(&statusWrapper, fb::IXpbBuilder::DPB,
 		reinterpret_cast<const std::uint8_t*>(options.getDpb().data()),
@@ -74,8 +73,7 @@ void Attachment::disconnectOrDrop(bool drop)
 {
 	assert(isValid());
 
-	const auto status = client->newStatus();
-	StatusWrapper statusWrapper{*client, status.get()};
+	StatusWrapper statusWrapper{*client};
 
 	if (drop)
 		handle->dropDatabase(&statusWrapper);

--- a/src/fb-cpp/Batch.cpp
+++ b/src/fb-cpp/Batch.cpp
@@ -36,15 +36,13 @@ using namespace fbcpp::impl;
 
 BatchCompletionState::BatchCompletionState(Client& client, FbUniquePtr<fb::IBatchCompletionState> handle) noexcept
 	: client{&client},
-	  status{client.newStatus()},
-	  statusWrapper{client, status.get()},
+	  statusWrapper{client},
 	  handle{std::move(handle)}
 {
 }
 
 BatchCompletionState::BatchCompletionState(BatchCompletionState&& o) noexcept
 	: client{o.client},
-	  status{std::move(o.status)},
 	  statusWrapper{std::move(o.statusWrapper)},
 	  handle{std::move(o.handle)}
 {
@@ -102,8 +100,7 @@ Batch::Batch(Statement& statement, Transaction& transaction, const BatchOptions&
 	: client{&statement.getAttachment().getClient()},
 	  transaction{&transaction},
 	  statement{&statement},
-	  status{client->newStatus()},
-	  statusWrapper{*client, status.get()}
+	  statusWrapper{*client}
 {
 	assert(statement.isValid());
 	assert(transaction.isValid());
@@ -118,8 +115,7 @@ Batch::Batch(Attachment& attachment, Transaction& transaction, std::string_view 
 	const BatchOptions& options)
 	: client{&attachment.getClient()},
 	  transaction{&transaction},
-	  status{client->newStatus()},
-	  statusWrapper{*client, status.get()}
+	  statusWrapper{*client}
 {
 	assert(attachment.isValid());
 	assert(transaction.isValid());
@@ -135,7 +131,6 @@ Batch::Batch(Batch&& o) noexcept
 	: client{o.client},
 	  transaction{o.transaction},
 	  statement{o.statement},
-	  status{std::move(o.status)},
 	  statusWrapper{std::move(o.statusWrapper)},
 	  handle{std::move(o.handle)}
 {

--- a/src/fb-cpp/Batch.h
+++ b/src/fb-cpp/Batch.h
@@ -250,7 +250,6 @@ namespace fbcpp
 
 	private:
 		Client* client;
-		FbUniquePtr<fb::IStatus> status;
 		impl::StatusWrapper statusWrapper;
 		FbUniquePtr<fb::IBatchCompletionState> handle;
 	};
@@ -447,7 +446,6 @@ namespace fbcpp
 		Client* client;
 		Transaction* transaction;
 		Statement* statement = nullptr;
-		FbUniquePtr<fb::IStatus> status;
 		impl::StatusWrapper statusWrapper;
 		FbRef<fb::IBatch> handle;
 		std::vector<Descriptor> inputDescriptors;

--- a/src/fb-cpp/Blob.cpp
+++ b/src/fb-cpp/Blob.cpp
@@ -38,8 +38,7 @@ using namespace fbcpp::impl;
 Blob::Blob(Attachment& attachment, Transaction& transaction, const BlobOptions& options)
 	: attachment{attachment},
 	  transaction{transaction},
-	  status{attachment.getClient().newStatus()},
-	  statusWrapper{attachment.getClient(), status.get()}
+	  statusWrapper{attachment.getClient()}
 {
 	assert(attachment.isValid());
 	assert(transaction.isValid());
@@ -54,8 +53,7 @@ Blob::Blob(Attachment& attachment, Transaction& transaction, const BlobId& blobI
 	: attachment{attachment},
 	  transaction{transaction},
 	  id{blobId},
-	  status{attachment.getClient().newStatus()},
-	  statusWrapper{attachment.getClient(), status.get()}
+	  statusWrapper{attachment.getClient()}
 {
 	assert(attachment.isValid());
 	assert(transaction.isValid());

--- a/src/fb-cpp/Blob.h
+++ b/src/fb-cpp/Blob.h
@@ -284,7 +284,6 @@ namespace fbcpp
 			: attachment{o.attachment},
 			  transaction{o.transaction},
 			  id{o.id},
-			  status{std::move(o.status)},
 			  statusWrapper{std::move(o.statusWrapper)},
 			  handle{std::move(o.handle)}
 		{
@@ -427,7 +426,6 @@ namespace fbcpp
 		Attachment& attachment;
 		Transaction& transaction;
 		BlobId id;
-		FbUniquePtr<fb::IStatus> status;
 		impl::StatusWrapper statusWrapper;
 		FbRef<fb::IBlob> handle;
 	};

--- a/src/fb-cpp/CalendarConverter.h
+++ b/src/fb-cpp/CalendarConverter.h
@@ -48,9 +48,8 @@ namespace fbcpp::impl
 	class CalendarConverter final
 	{
 	public:
-		explicit CalendarConverter(Client& client, StatusWrapper* statusWrapper)
-			: client{&client},
-			  statusWrapper{statusWrapper}
+		explicit CalendarConverter(Client& client)
+			: client{&client}
 		{
 		}
 
@@ -236,7 +235,7 @@ namespace fbcpp::impl
 				subseconds);
 		}
 
-		OpaqueTimeTz timeTzToOpaqueTimeTz(const TimeTz& timeTz)
+		OpaqueTimeTz timeTzToOpaqueTimeTz(StatusWrapper* statusWrapper, const TimeTz& timeTz)
 		{
 			const auto duration = timeTz.utcTime.to_duration();
 
@@ -259,7 +258,8 @@ namespace fbcpp::impl
 			return opaque;
 		}
 
-		TimeTz opaqueTimeTzToTimeTz(const OpaqueTimeTz& opaqueTime, std::string* decodedTimeZoneName = nullptr)
+		TimeTz opaqueTimeTzToTimeTz(
+			StatusWrapper* statusWrapper, const OpaqueTimeTz& opaqueTime, std::string* decodedTimeZoneName = nullptr)
 		{
 			const auto ticks = static_cast<std::int64_t>(opaqueTime.value.utc_time) * 100;
 
@@ -282,12 +282,12 @@ namespace fbcpp::impl
 			return timeTz;
 		}
 
-		OpaqueTimeTz stringToOpaqueTimeTz(std::string_view value)
+		OpaqueTimeTz stringToOpaqueTimeTz(StatusWrapper* statusWrapper, std::string_view value)
 		{
-			return timeTzToOpaqueTimeTz(stringToTimeTz(value));
+			return timeTzToOpaqueTimeTz(statusWrapper, stringToTimeTz(statusWrapper, value));
 		}
 
-		std::string opaqueTimeTzToString(const OpaqueTimeTz& time)
+		std::string opaqueTimeTzToString(StatusWrapper* statusWrapper, const OpaqueTimeTz& time)
 		{
 			unsigned hours;
 			unsigned minutes;
@@ -301,7 +301,7 @@ namespace fbcpp::impl
 			return std::format("{:02}:{:02}:{:02}.{:04} {}", hours, minutes, seconds, fractions, timeZoneBuffer.data());
 		}
 
-		TimeTz stringToTimeTz(std::string_view value)
+		TimeTz stringToTimeTz(StatusWrapper* statusWrapper, std::string_view value)
 		{
 			static const std::regex pattern(
 				R"(^\s*([0-9]{2})\s*:\s*([0-9]{2})\s*:\s*([0-9]{2})(?:\s*\.\s*([0-9]{1,4}))?\s+([^\s]+)\s*$)");
@@ -363,7 +363,7 @@ namespace fbcpp::impl
 			client->getUtil()->encodeTimeTz(
 				statusWrapper, &encoded.value, hours, minutes, seconds, fractions, timeZoneString.c_str());
 
-			return opaqueTimeTzToTimeTz(encoded);
+			return opaqueTimeTzToTimeTz(statusWrapper, encoded);
 		}
 
 		// FIXME: review
@@ -509,7 +509,7 @@ namespace fbcpp::impl
 			return std::format("{} {}", dateString, timeString);
 		}
 
-		OpaqueTimestampTz timestampTzToOpaqueTimestampTz(const TimestampTz& timestampTz)
+		OpaqueTimestampTz timestampTzToOpaqueTimestampTz(StatusWrapper* statusWrapper, const TimestampTz& timestampTz)
 		{
 			OpaqueTimestampTz opaque;
 
@@ -522,7 +522,7 @@ namespace fbcpp::impl
 			return opaque;
 		}
 
-		TimestampTz opaqueTimestampTzToTimestampTz(
+		TimestampTz opaqueTimestampTzToTimestampTz(StatusWrapper* statusWrapper,
 			const OpaqueTimestampTz& opaqueTimestamp, std::string* decodedTimeZoneName = nullptr)
 		{
 			const auto ticks =
@@ -553,12 +553,12 @@ namespace fbcpp::impl
 			return timestampTz;
 		}
 
-		OpaqueTimestampTz stringToOpaqueTimestampTz(std::string_view value)
+		OpaqueTimestampTz stringToOpaqueTimestampTz(StatusWrapper* statusWrapper, std::string_view value)
 		{
-			return timestampTzToOpaqueTimestampTz(stringToTimestampTz(value));
+			return timestampTzToOpaqueTimestampTz(statusWrapper, stringToTimestampTz(statusWrapper, value));
 		}
 
-		std::string opaqueTimestampTzToString(const OpaqueTimestampTz& timestamp)
+		std::string opaqueTimestampTzToString(StatusWrapper* statusWrapper, const OpaqueTimestampTz& timestamp)
 		{
 			unsigned year;
 			unsigned month;
@@ -576,7 +576,7 @@ namespace fbcpp::impl
 				seconds, subseconds, timeZoneBuffer.data());
 		}
 
-		TimestampTz stringToTimestampTz(std::string_view value)
+		TimestampTz stringToTimestampTz(StatusWrapper* statusWrapper, std::string_view value)
 		{
 			static const std::regex pattern(
 				R"(^\s*([0-9]{4})\s*-\s*([0-9]{2})\s*-\s*([0-9]{2})\s+([0-9]{2})\s*:\s*([0-9]{2})\s*:\s*([0-9]{2})(?:\s*\.\s*([0-9]{1,4}))?\s+([^\s]+)\s*$)");
@@ -660,7 +660,7 @@ namespace fbcpp::impl
 				throwInvalidTimestampValue();
 
 			std::string resolvedTimeZoneName;
-			opaqueTimestampTzToTimestampTz(encoded, &resolvedTimeZoneName);
+			opaqueTimestampTzToTimestampTz(statusWrapper, encoded, &resolvedTimeZoneName);
 
 			return TimestampTz{utcTimestamp, resolvedTimeZoneName};
 		}
@@ -713,7 +713,6 @@ namespace fbcpp::impl
 			std::chrono::year{1858} / std::chrono::November / 17,
 		};
 		Client* client;
-		StatusWrapper* statusWrapper;
 	};
 }  // namespace fbcpp::impl
 

--- a/src/fb-cpp/Client.cpp
+++ b/src/fb-cpp/Client.cpp
@@ -35,8 +35,7 @@ void Client::shutdown()
 	assert(isValid());
 
 	auto dispatcher = fbRef(master->getDispatcher());
-	const auto status = newStatus();
-	StatusWrapper statusWrapper{*this, status.get()};
+	StatusWrapper statusWrapper{*this};
 
 	dispatcher->shutdown(&statusWrapper, 0, fb_shutrsn_app_stopped);
 

--- a/src/fb-cpp/EventListener.cpp
+++ b/src/fb-cpp/EventListener.cpp
@@ -104,8 +104,7 @@ EventListener::EventListener(Attachment& attachment, const std::vector<std::stri
 	listening = true;
 	running = true;
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	eventsHandle.reset(attachment.getHandle()->queEvents(
 		&statusWrapper, &firebirdCallback, static_cast<unsigned>(eventBuffer.size()), eventBuffer.data()));
@@ -249,8 +248,7 @@ void EventListener::handleEvent(unsigned length, const std::uint8_t* events)
 			return;
 		}
 
-		const auto status = client.newStatus();
-		StatusWrapper statusWrapper{client, status.get()};
+		StatusWrapper statusWrapper{client};
 		FbRef<fb::IEvents> newHandle;
 
 		try
@@ -351,8 +349,7 @@ void EventListener::cancelEventsHandle()
 	if (!handle)
 		return;
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	handle->cancel(&statusWrapper);
 }

--- a/src/fb-cpp/Exception.cpp
+++ b/src/fb-cpp/Exception.cpp
@@ -32,6 +32,17 @@ using namespace fbcpp;
 using namespace fbcpp::impl;
 
 
+fb::IStatus* StatusWrapper::getStatus() const
+{
+	if (!status)
+	{
+		status = client->newStatus().release();
+		statusOwner = true;
+	}
+
+	return status;
+}
+
 void StatusWrapper::checkException(StatusWrapper* status)
 {
 	if (status->dirty && (status->getState() & fb::IStatus::STATE_ERRORS))

--- a/src/fb-cpp/Exception.h
+++ b/src/fb-cpp/Exception.h
@@ -45,10 +45,50 @@ namespace fbcpp::impl
 	class StatusWrapper : public fb::IStatusImpl<StatusWrapper, StatusWrapper>
 	{
 	public:
-		explicit StatusWrapper(Client& client, IStatus* status)
+		explicit StatusWrapper(Client& client, IStatus* status = nullptr)
 			: client{&client},
 			  status{status}
 		{
+		}
+
+		StatusWrapper(StatusWrapper&& o) noexcept
+			: client{o.client},
+			  status{o.status},
+			  statusOwner{o.statusOwner},
+			  dirty{o.dirty}
+		{
+			o.status = nullptr;
+			o.statusOwner = false;
+			o.dirty = false;
+		}
+
+		StatusWrapper& operator=(StatusWrapper&& o) noexcept
+		{
+			if (this != &o)
+			{
+				if (statusOwner && status)
+					status->dispose();
+
+				client = o.client;
+				status = o.status;
+				statusOwner = o.statusOwner;
+				dirty = o.dirty;
+
+				o.status = nullptr;
+				o.statusOwner = false;
+				o.dirty = false;
+			}
+
+			return *this;
+		}
+
+		StatusWrapper(const StatusWrapper&) = delete;
+		StatusWrapper& operator=(const StatusWrapper&) = delete;
+
+		~StatusWrapper()
+		{
+			if (statusOwner && status)
+				status->dispose();
 		}
 
 	public:
@@ -66,7 +106,7 @@ namespace fbcpp::impl
 			if (dirty)
 			{
 				dirty = false;
-				status->init();
+				getStatus()->init();
 			}
 		}
 
@@ -105,8 +145,11 @@ namespace fbcpp::impl
 		void dispose() noexcept override
 		{
 			// Disposes only the delegated status. Let the user destroy this instance.
-			status->dispose();
+			if (status)
+				status->dispose();
+
 			status = nullptr;
+			statusOwner = false;
 		}
 
 		void init() noexcept override
@@ -116,52 +159,55 @@ namespace fbcpp::impl
 
 		unsigned getState() const noexcept override
 		{
-			return dirty ? status->getState() : 0;
+			return dirty ? getStatus()->getState() : 0;
 		}
 
 		void setErrors2(unsigned length, const intptr_t* value) noexcept override
 		{
 			dirty = true;
-			status->setErrors2(length, value);
+			getStatus()->setErrors2(length, value);
 		}
 
 		void setWarnings2(unsigned length, const intptr_t* value) noexcept override
 		{
 			dirty = true;
-			status->setWarnings2(length, value);
+			getStatus()->setWarnings2(length, value);
 		}
 
 		void setErrors(const intptr_t* value) noexcept override
 		{
 			dirty = true;
-			status->setErrors(value);
+			getStatus()->setErrors(value);
 		}
 
 		void setWarnings(const intptr_t* value) noexcept override
 		{
 			dirty = true;
-			status->setWarnings(value);
+			getStatus()->setWarnings(value);
 		}
 
 		const intptr_t* getErrors() const noexcept override
 		{
-			return dirty ? status->getErrors() : cleanStatus();
+			return dirty ? getStatus()->getErrors() : cleanStatus();
 		}
 
 		const intptr_t* getWarnings() const noexcept override
 		{
-			return dirty ? status->getWarnings() : cleanStatus();
+			return dirty ? getStatus()->getWarnings() : cleanStatus();
 		}
 
 		IStatus* clone() const noexcept override
 		{
-			return status->clone();
+			return getStatus()->clone();
 		}
 
 	protected:
 		Client* client;
-		IStatus* status;
+		mutable IStatus* status;
+		mutable bool statusOwner = false;
 		bool dirty = false;
+
+		IStatus* getStatus() const;
 
 		static const intptr_t* cleanStatus() noexcept
 		{

--- a/src/fb-cpp/NumericConverter.h
+++ b/src/fb-cpp/NumericConverter.h
@@ -147,9 +147,8 @@ namespace fbcpp::impl
 	class NumericConverter final
 	{
 	public:
-		explicit NumericConverter(Client& client, StatusWrapper* statusWrapper)
-			: client{&client},
-			  statusWrapper{statusWrapper}
+		explicit NumericConverter(Client& client)
+			: client{&client}
 		{
 		}
 
@@ -354,7 +353,7 @@ namespace fbcpp::impl
 				return from.str();
 		}
 
-		std::string opaqueInt128ToString(const OpaqueInt128& opaqueInt128, int scale)
+		std::string opaqueInt128ToString(StatusWrapper* statusWrapper, const OpaqueInt128& opaqueInt128, int scale)
 		{
 			const auto int128Util = client->getInt128Util(statusWrapper);
 			char buffer[fb::IInt128::STRING_SIZE + 1];
@@ -362,7 +361,7 @@ namespace fbcpp::impl
 			return buffer;
 		}
 
-		std::string opaqueDecFloat16ToString(const OpaqueDecFloat16& opaqueDecFloat16)
+		std::string opaqueDecFloat16ToString(StatusWrapper* statusWrapper, const OpaqueDecFloat16& opaqueDecFloat16)
 		{
 			const auto decFloat16Util = client->getDecFloat16Util(statusWrapper);
 			char buffer[fb::IDecFloat16::STRING_SIZE + 1];
@@ -370,7 +369,7 @@ namespace fbcpp::impl
 			return buffer;
 		}
 
-		std::string opaqueDecFloat34ToString(const OpaqueDecFloat34& opaqueDecFloat34)
+		std::string opaqueDecFloat34ToString(StatusWrapper* statusWrapper, const OpaqueDecFloat34& opaqueDecFloat34)
 		{
 			const auto decFloat34Util = client->getDecFloat34Util(statusWrapper);
 			char buffer[fb::IDecFloat34::STRING_SIZE + 1];
@@ -399,7 +398,8 @@ namespace fbcpp::impl
 			return boostInt128;
 		}
 
-		OpaqueDecFloat16 boostDecFloat16ToOpaqueDecFloat16(const BoostDecFloat16& boostDecFloat16)
+		OpaqueDecFloat16 boostDecFloat16ToOpaqueDecFloat16(
+			StatusWrapper* statusWrapper, const BoostDecFloat16& boostDecFloat16)
 		{
 			const auto decFloat16Util = client->getDecFloat16Util(statusWrapper);
 			OpaqueDecFloat16 opaqueDecFloat16;
@@ -407,12 +407,14 @@ namespace fbcpp::impl
 			return opaqueDecFloat16;
 		}
 
-		BoostDecFloat16 opaqueDecFloat16ToBoostDecFloat16(const OpaqueDecFloat16& opaqueDecFloat16)
+		BoostDecFloat16 opaqueDecFloat16ToBoostDecFloat16(
+			StatusWrapper* statusWrapper, const OpaqueDecFloat16& opaqueDecFloat16)
 		{
-			return BoostDecFloat16{opaqueDecFloat16ToString(opaqueDecFloat16)};
+			return BoostDecFloat16{opaqueDecFloat16ToString(statusWrapper, opaqueDecFloat16)};
 		}
 
-		OpaqueDecFloat34 boostDecFloat34ToOpaqueDecFloat34(const BoostDecFloat34& boostDecFloat34)
+		OpaqueDecFloat34 boostDecFloat34ToOpaqueDecFloat34(
+			StatusWrapper* statusWrapper, const BoostDecFloat34& boostDecFloat34)
 		{
 			const auto decFloat34Util = client->getDecFloat34Util(statusWrapper);
 			OpaqueDecFloat34 opaqueDecFloat34;
@@ -420,9 +422,10 @@ namespace fbcpp::impl
 			return opaqueDecFloat34;
 		}
 
-		BoostDecFloat34 opaqueDecFloat34ToBoostDecFloat34(const OpaqueDecFloat34& opaqueDecFloat34)
+		BoostDecFloat34 opaqueDecFloat34ToBoostDecFloat34(
+			StatusWrapper* statusWrapper, const OpaqueDecFloat34& opaqueDecFloat34)
 		{
-			return BoostDecFloat34{opaqueDecFloat34ToString(opaqueDecFloat34)};
+			return BoostDecFloat34{opaqueDecFloat34ToString(statusWrapper, opaqueDecFloat34)};
 		}
 #endif
 
@@ -574,7 +577,6 @@ namespace fbcpp::impl
 
 	private:
 		Client* client;
-		StatusWrapper* statusWrapper;
 	};
 }  // namespace fbcpp::impl
 

--- a/src/fb-cpp/NumericConverter.h
+++ b/src/fb-cpp/NumericConverter.h
@@ -356,7 +356,7 @@ namespace fbcpp::impl
 
 		std::string opaqueInt128ToString(const OpaqueInt128& opaqueInt128, int scale)
 		{
-			const auto int128Util = client->getUtil()->getInt128(statusWrapper);
+			const auto int128Util = client->getInt128Util(statusWrapper);
 			char buffer[fb::IInt128::STRING_SIZE + 1];
 			int128Util->toString(statusWrapper, &opaqueInt128, scale, static_cast<unsigned>(sizeof(buffer)), buffer);
 			return buffer;

--- a/src/fb-cpp/Row.h
+++ b/src/fb-cpp/Row.h
@@ -71,13 +71,15 @@ namespace fbcpp
 		///
 		/// @param message Pointer to the raw row data.
 		/// @param descriptors Column descriptors.
+		/// @param statusWrapper Status wrapper used for Firebird conversions.
 		/// @param numericConverter Numeric converter.
 		/// @param calendarConverter Calendar converter.
 		///
-		Row(const std::byte* message, const std::vector<Descriptor>& descriptors,
+		Row(const std::byte* message, const std::vector<Descriptor>& descriptors, impl::StatusWrapper& statusWrapper,
 			impl::NumericConverter& numericConverter, impl::CalendarConverter& calendarConverter)
 			: message{message},
 			  descriptors{&descriptors},
+			  statusWrapper{&statusWrapper},
 			  numericConverter{&numericConverter},
 			  calendarConverter{&calendarConverter}
 		{
@@ -435,7 +437,7 @@ namespace fbcpp
 			{
 				case DescriptorAdjustedType::TIME_TZ:
 					return getCalendarConverter().opaqueTimeTzToTimeTz(
-						*reinterpret_cast<const OpaqueTimeTz*>(&message[descriptor.offset]));
+						getStatusWrapper(), *reinterpret_cast<const OpaqueTimeTz*>(&message[descriptor.offset]));
 
 				default:
 					throwInvalidType("TimeTz", descriptor.adjustedType);
@@ -476,7 +478,7 @@ namespace fbcpp
 			{
 				case DescriptorAdjustedType::TIMESTAMP_TZ:
 					return getCalendarConverter().opaqueTimestampTzToTimestampTz(
-						*reinterpret_cast<const OpaqueTimestampTz*>(&message[descriptor.offset]));
+						getStatusWrapper(), *reinterpret_cast<const OpaqueTimestampTz*>(&message[descriptor.offset]));
 
 				default:
 					throwInvalidType("TimestampTz", descriptor.adjustedType);
@@ -558,7 +560,7 @@ namespace fbcpp
 
 				case DescriptorAdjustedType::INT128:
 					return getNumericConverter().opaqueInt128ToString(
-						*reinterpret_cast<const OpaqueInt128*>(data), descriptor.scale);
+						getStatusWrapper(), *reinterpret_cast<const OpaqueInt128*>(data), descriptor.scale);
 
 				case DescriptorAdjustedType::FLOAT:
 					return getNumericConverter().numberToString(*reinterpret_cast<const float*>(data));
@@ -577,19 +579,20 @@ namespace fbcpp
 						*reinterpret_cast<const OpaqueTimestamp*>(data));
 
 				case DescriptorAdjustedType::TIME_TZ:
-					return getCalendarConverter().opaqueTimeTzToString(*reinterpret_cast<const OpaqueTimeTz*>(data));
+					return getCalendarConverter().opaqueTimeTzToString(
+						getStatusWrapper(), *reinterpret_cast<const OpaqueTimeTz*>(data));
 
 				case DescriptorAdjustedType::TIMESTAMP_TZ:
 					return getCalendarConverter().opaqueTimestampTzToString(
-						*reinterpret_cast<const OpaqueTimestampTz*>(data));
+						getStatusWrapper(), *reinterpret_cast<const OpaqueTimestampTz*>(data));
 
 				case DescriptorAdjustedType::DECFLOAT16:
 					return getNumericConverter().opaqueDecFloat16ToString(
-						*reinterpret_cast<const OpaqueDecFloat16*>(data));
+						getStatusWrapper(), *reinterpret_cast<const OpaqueDecFloat16*>(data));
 
 				case DescriptorAdjustedType::DECFLOAT34:
 					return getNumericConverter().opaqueDecFloat34ToString(
-						*reinterpret_cast<const OpaqueDecFloat34*>(data));
+						getStatusWrapper(), *reinterpret_cast<const OpaqueDecFloat34*>(data));
 
 				case DescriptorAdjustedType::STRING:
 					return std::string{reinterpret_cast<const char*>(data + sizeof(std::uint16_t)),
@@ -934,13 +937,13 @@ namespace fbcpp
 
 				case DescriptorAdjustedType::DECFLOAT16:
 					boostDecFloat16.emplace(getNumericConverter().opaqueDecFloat16ToBoostDecFloat16(
-						*reinterpret_cast<const OpaqueDecFloat16*>(data)));
+						getStatusWrapper(), *reinterpret_cast<const OpaqueDecFloat16*>(data)));
 					data = reinterpret_cast<const std::byte*>(&boostDecFloat16.value());
 					break;
 
 				case DescriptorAdjustedType::DECFLOAT34:
 					boostDecFloat34.emplace(getNumericConverter().opaqueDecFloat34ToBoostDecFloat34(
-						*reinterpret_cast<const OpaqueDecFloat34*>(data)));
+						getStatusWrapper(), *reinterpret_cast<const OpaqueDecFloat34*>(data)));
 					data = reinterpret_cast<const std::byte*>(&boostDecFloat34.value());
 					break;
 #endif
@@ -1024,8 +1027,14 @@ namespace fbcpp
 	private:
 		const std::byte* message = nullptr;
 		const std::vector<Descriptor>* descriptors = nullptr;
+		impl::StatusWrapper* statusWrapper = nullptr;
 		impl::NumericConverter* numericConverter = nullptr;
 		impl::CalendarConverter* calendarConverter = nullptr;
+
+		impl::StatusWrapper* getStatusWrapper() const
+		{
+			return statusWrapper;
+		}
 
 		const std::vector<Descriptor>& getDescriptors() const
 		{

--- a/src/fb-cpp/Row.h
+++ b/src/fb-cpp/Row.h
@@ -1,0 +1,1231 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 F.D.Castel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FBCPP_ROW_H
+#define FBCPP_ROW_H
+
+#include "config.h"
+#include "fb-api.h"
+#include "types.h"
+#include "Blob.h"
+#include "NumericConverter.h"
+#include "CalendarConverter.h"
+#include "Descriptor.h"
+#include "Exception.h"
+#include "StructBinding.h"
+#include "VariantTypeTraits.h"
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#endif
+
+
+///
+/// fb-cpp namespace.
+///
+namespace fbcpp
+{
+	///
+	/// @brief A lightweight, non-owning view of a single row's data with typed accessors.
+	///
+	/// Row provides typed access to column values in a message buffer, using
+	/// descriptors to interpret the raw bytes. It is produced by RowSet for any
+	/// fetched row.
+	///
+	class Row final
+	{
+	public:
+		Row() = default;
+
+		///
+		/// @brief Constructs a Row view over the given message buffer.
+		///
+		/// @param message Pointer to the raw row data.
+		/// @param descriptors Column descriptors.
+		/// @param numericConverter Numeric converter.
+		/// @param calendarConverter Calendar converter.
+		///
+		Row(const std::byte* message, const std::vector<Descriptor>& descriptors,
+			impl::NumericConverter& numericConverter, impl::CalendarConverter& calendarConverter)
+			: message{message},
+			  descriptors{&descriptors},
+			  numericConverter{&numericConverter},
+			  calendarConverter{&calendarConverter}
+		{
+		}
+
+	public:
+		///
+		/// @name Result reading
+		/// @{
+
+		///
+		/// @brief Reports whether the row has a null at the given column.
+		///
+		bool isNull(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+			return *reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE;
+		}
+
+		///
+		/// @brief Reads a boolean column.
+		///
+		std::optional<bool> getBool(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::BOOLEAN:
+					return message[descriptor.offset] != std::byte{0};
+
+				default:
+					throwInvalidType("bool", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a 16-bit signed integer column.
+		///
+		std::optional<std::int16_t> getInt16(unsigned index)
+		{
+			std::optional<int> scale{0};
+			return getNumber<std::int16_t>(index, scale, "std::int16_t");
+		}
+
+		///
+		/// @brief Reads a scaled 16-bit signed integer column.
+		///
+		std::optional<ScaledInt16> getScaledInt16(unsigned index)
+		{
+			std::optional<int> scale;
+			const auto value = getNumber<std::int16_t>(index, scale, "ScaledInt16");
+			return value.has_value() ? std::optional{ScaledInt16{value.value(), scale.value()}} : std::nullopt;
+		}
+
+		///
+		/// @brief Reads a 32-bit signed integer column.
+		///
+		std::optional<std::int32_t> getInt32(unsigned index)
+		{
+			std::optional<int> scale{0};
+			return getNumber<std::int32_t>(index, scale, "std::int32_t");
+		}
+
+		///
+		/// @brief Reads a scaled 32-bit signed integer column.
+		///
+		std::optional<ScaledInt32> getScaledInt32(unsigned index)
+		{
+			std::optional<int> scale;
+			const auto value = getNumber<std::int32_t>(index, scale, "ScaledInt32");
+			return value.has_value() ? std::optional{ScaledInt32{value.value(), scale.value()}} : std::nullopt;
+		}
+
+		///
+		/// @brief Reads a 64-bit signed integer column.
+		///
+		std::optional<std::int64_t> getInt64(unsigned index)
+		{
+			std::optional<int> scale{0};
+			return getNumber<std::int64_t>(index, scale, "std::int64_t");
+		}
+
+		///
+		/// @brief Reads a scaled 64-bit signed integer column.
+		///
+		std::optional<ScaledInt64> getScaledInt64(unsigned index)
+		{
+			std::optional<int> scale;
+			const auto value = getNumber<std::int64_t>(index, scale, "ScaledInt64");
+			return value.has_value() ? std::optional{ScaledInt64{value.value(), scale.value()}} : std::nullopt;
+		}
+
+		///
+		/// @brief Reads a Firebird scaled 128-bit integer column.
+		///
+		std::optional<ScaledOpaqueInt128> getScaledOpaqueInt128(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::INT128:
+					return ScaledOpaqueInt128{
+						OpaqueInt128{*reinterpret_cast<const OpaqueInt128*>(&message[descriptor.offset])},
+						descriptor.scale};
+
+				default:
+					throwInvalidType("ScaledOpaqueInt128", descriptor.adjustedType);
+			}
+		}
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+		///
+		/// @brief Reads a Boost 128-bit integer column.
+		///
+		std::optional<BoostInt128> getBoostInt128(unsigned index)
+		{
+			std::optional<int> scale{0};
+			const auto value = getNumber<BoostInt128>(index, scale, "BoostInt128");
+			return value.has_value() ? std::optional{value.value()} : std::nullopt;
+		}
+
+		///
+		/// @brief Reads a scaled Boost 128-bit integer column.
+		///
+		std::optional<ScaledBoostInt128> getScaledBoostInt128(unsigned index)
+		{
+			std::optional<int> scale;
+			const auto value = getNumber<BoostInt128>(index, scale, "ScaledBoostInt128");
+			return value.has_value() ? std::optional{ScaledBoostInt128{value.value(), scale.value()}} : std::nullopt;
+		}
+#endif
+
+		///
+		/// @brief Reads a single precision floating-point column.
+		///
+		std::optional<float> getFloat(unsigned index)
+		{
+			std::optional<int> scale{0};
+			return getNumber<float>(index, scale, "float");
+		}
+
+		///
+		/// @brief Reads a double precision floating-point column.
+		///
+		std::optional<double> getDouble(unsigned index)
+		{
+			std::optional<int> scale{0};
+			return getNumber<double>(index, scale, "double");
+		}
+
+		///
+		/// @brief Reads a Firebird 16-digit decimal floating-point column.
+		///
+		std::optional<OpaqueDecFloat16> getOpaqueDecFloat16(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::DECFLOAT16:
+					return OpaqueDecFloat16{*reinterpret_cast<const OpaqueDecFloat16*>(&message[descriptor.offset])};
+
+				default:
+					throwInvalidType("OpaqueDecFloat16", descriptor.adjustedType);
+			}
+		}
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+		///
+		/// @brief Reads a Boost-based 16-digit decimal floating-point column.
+		///
+		std::optional<BoostDecFloat16> getBoostDecFloat16(unsigned index)
+		{
+			std::optional<int> scale{0};
+			return getNumber<BoostDecFloat16>(index, scale, "BoostDecFloat16");
+		}
+#endif
+
+		///
+		/// @brief Reads a Firebird 34-digit decimal floating-point column.
+		///
+		std::optional<OpaqueDecFloat34> getOpaqueDecFloat34(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::DECFLOAT34:
+					return OpaqueDecFloat34{*reinterpret_cast<const OpaqueDecFloat34*>(&message[descriptor.offset])};
+
+				default:
+					throwInvalidType("OpaqueDecFloat34", descriptor.adjustedType);
+			}
+		}
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+		///
+		/// @brief Reads a Boost-based 34-digit decimal floating-point column.
+		///
+		std::optional<BoostDecFloat34> getBoostDecFloat34(unsigned index)
+		{
+			std::optional<int> scale{0};
+			return getNumber<BoostDecFloat34>(index, scale, "BoostDecFloat34");
+		}
+#endif
+
+		///
+		/// @brief Reads a date column.
+		///
+		std::optional<Date> getDate(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::DATE:
+					return getCalendarConverter().opaqueDateToDate(
+						*reinterpret_cast<const OpaqueDate*>(&message[descriptor.offset]));
+
+				default:
+					throwInvalidType("Date", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a raw date column in Firebird's representation.
+		///
+		std::optional<OpaqueDate> getOpaqueDate(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::DATE:
+					return OpaqueDate{*reinterpret_cast<const OpaqueDate*>(&message[descriptor.offset])};
+
+				default:
+					throwInvalidType("OpaqueDate", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a time-of-day column without timezone.
+		///
+		std::optional<Time> getTime(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::TIME:
+					return getCalendarConverter().opaqueTimeToTime(
+						*reinterpret_cast<const OpaqueTime*>(&message[descriptor.offset]));
+
+				default:
+					throwInvalidType("Time", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a raw time-of-day column in Firebird's representation.
+		///
+		std::optional<OpaqueTime> getOpaqueTime(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::TIME:
+					return OpaqueTime{*reinterpret_cast<const OpaqueTime*>(&message[descriptor.offset])};
+
+				default:
+					throwInvalidType("OpaqueTime", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a timestamp column without timezone.
+		///
+		std::optional<Timestamp> getTimestamp(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::TIMESTAMP:
+					return getCalendarConverter().opaqueTimestampToTimestamp(
+						*reinterpret_cast<const OpaqueTimestamp*>(&message[descriptor.offset]));
+
+				default:
+					throwInvalidType("Timestamp", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a raw timestamp column in Firebird's representation.
+		///
+		std::optional<OpaqueTimestamp> getOpaqueTimestamp(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::TIMESTAMP:
+					return OpaqueTimestamp{*reinterpret_cast<const OpaqueTimestamp*>(&message[descriptor.offset])};
+
+				default:
+					throwInvalidType("OpaqueTimestamp", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a time-of-day column with timezone.
+		///
+		std::optional<TimeTz> getTimeTz(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::TIME_TZ:
+					return getCalendarConverter().opaqueTimeTzToTimeTz(
+						*reinterpret_cast<const OpaqueTimeTz*>(&message[descriptor.offset]));
+
+				default:
+					throwInvalidType("TimeTz", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a raw time-of-day column with timezone in Firebird's representation.
+		///
+		std::optional<OpaqueTimeTz> getOpaqueTimeTz(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::TIME_TZ:
+					return OpaqueTimeTz{*reinterpret_cast<const OpaqueTimeTz*>(&message[descriptor.offset])};
+
+				default:
+					throwInvalidType("OpaqueTimeTz", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a timestamp-with-time-zone column.
+		///
+		std::optional<TimestampTz> getTimestampTz(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::TIMESTAMP_TZ:
+					return getCalendarConverter().opaqueTimestampTzToTimestampTz(
+						*reinterpret_cast<const OpaqueTimestampTz*>(&message[descriptor.offset]));
+
+				default:
+					throwInvalidType("TimestampTz", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a raw timestamp-with-time-zone column in Firebird's representation.
+		///
+		std::optional<OpaqueTimestampTz> getOpaqueTimestampTz(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::TIMESTAMP_TZ:
+					return OpaqueTimestampTz{*reinterpret_cast<const OpaqueTimestampTz*>(&message[descriptor.offset])};
+
+				default:
+					throwInvalidType("OpaqueTimestampTz", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a blob identifier column.
+		///
+		std::optional<BlobId> getBlobId(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::BLOB:
+				{
+					BlobId value;
+					value.id = *reinterpret_cast<const ISC_QUAD*>(&message[descriptor.offset]);
+					return value;
+				}
+
+				default:
+					throwInvalidType("BlobId", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @brief Reads a textual column, applying number-to-string conversions when needed.
+		///
+		std::optional<std::string> getString(unsigned index)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			const auto data = &message[descriptor.offset];
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::BOOLEAN:
+					return (message[descriptor.offset] != std::byte{0}) ? std::string{"true"} : std::string{"false"};
+
+				case DescriptorAdjustedType::INT16:
+					return getNumericConverter().numberToString(
+						ScaledInt16{*reinterpret_cast<const std::int16_t*>(data), descriptor.scale});
+
+				case DescriptorAdjustedType::INT32:
+					return getNumericConverter().numberToString(
+						ScaledInt32{*reinterpret_cast<const std::int32_t*>(data), descriptor.scale});
+
+				case DescriptorAdjustedType::INT64:
+					return getNumericConverter().numberToString(
+						ScaledInt64{*reinterpret_cast<const std::int64_t*>(data), descriptor.scale});
+
+				case DescriptorAdjustedType::INT128:
+					return getNumericConverter().opaqueInt128ToString(
+						*reinterpret_cast<const OpaqueInt128*>(data), descriptor.scale);
+
+				case DescriptorAdjustedType::FLOAT:
+					return getNumericConverter().numberToString(*reinterpret_cast<const float*>(data));
+
+				case DescriptorAdjustedType::DOUBLE:
+					return getNumericConverter().numberToString(*reinterpret_cast<const double*>(data));
+
+				case DescriptorAdjustedType::DATE:
+					return getCalendarConverter().opaqueDateToString(*reinterpret_cast<const OpaqueDate*>(data));
+
+				case DescriptorAdjustedType::TIME:
+					return getCalendarConverter().opaqueTimeToString(*reinterpret_cast<const OpaqueTime*>(data));
+
+				case DescriptorAdjustedType::TIMESTAMP:
+					return getCalendarConverter().opaqueTimestampToString(
+						*reinterpret_cast<const OpaqueTimestamp*>(data));
+
+				case DescriptorAdjustedType::TIME_TZ:
+					return getCalendarConverter().opaqueTimeTzToString(*reinterpret_cast<const OpaqueTimeTz*>(data));
+
+				case DescriptorAdjustedType::TIMESTAMP_TZ:
+					return getCalendarConverter().opaqueTimestampTzToString(
+						*reinterpret_cast<const OpaqueTimestampTz*>(data));
+
+				case DescriptorAdjustedType::DECFLOAT16:
+					return getNumericConverter().opaqueDecFloat16ToString(
+						*reinterpret_cast<const OpaqueDecFloat16*>(data));
+
+				case DescriptorAdjustedType::DECFLOAT34:
+					return getNumericConverter().opaqueDecFloat34ToString(
+						*reinterpret_cast<const OpaqueDecFloat34*>(data));
+
+				case DescriptorAdjustedType::STRING:
+					return std::string{reinterpret_cast<const char*>(data + sizeof(std::uint16_t)),
+						*reinterpret_cast<const std::uint16_t*>(data)};
+
+				default:
+					throwInvalidType("std::string", descriptor.adjustedType);
+			}
+		}
+
+		///
+		/// @}
+		///
+
+		///
+		/// @brief Retrieves a column using the most appropriate typed accessor specialization.
+		///
+		template <typename T>
+		T get(unsigned index);
+
+		///
+		/// @brief Retrieves all output columns into a user-defined aggregate struct.
+		///
+		template <Aggregate T>
+		T get()
+		{
+			using namespace impl::reflection;
+
+			constexpr std::size_t N = fieldCountV<T>;
+
+			if (N != getDescriptors().size())
+			{
+				throw FbCppException("Struct field count (" + std::to_string(N) +
+					") does not match output column count (" + std::to_string(getDescriptors().size()) + ")");
+			}
+
+			return getStruct<T>(std::make_index_sequence<N>{});
+		}
+
+		///
+		/// @brief Retrieves all output columns into a tuple-like type.
+		///
+		template <TupleLike T>
+		T get()
+		{
+			using namespace impl::reflection;
+
+			constexpr std::size_t N = std::tuple_size_v<T>;
+
+			if (N != getDescriptors().size())
+			{
+				throw FbCppException("Tuple element count (" + std::to_string(N) +
+					") does not match output column count (" + std::to_string(getDescriptors().size()) + ")");
+			}
+
+			return getTuple<T>(std::make_index_sequence<N>{});
+		}
+
+		///
+		/// @brief Retrieves a column value as a user-defined variant type.
+		///
+		template <VariantLike V>
+		V get(unsigned index)
+		{
+			using namespace impl::reflection;
+
+			static_assert(variantAlternativesSupportedV<V>,
+				"Variant contains unsupported types. All variant alternatives must be types supported by fb-cpp "
+				"(e.g., std::int32_t, std::string, Date, ScaledOpaqueInt128, etc.). Check VariantTypeTraits.h for the "
+				"complete list of supported types.");
+
+			const auto& descriptor = getDescriptor(index);
+
+			if (isNull(index))
+			{
+				if constexpr (variantContainsV<std::monostate, V>)
+					return V{std::monostate{}};
+				else
+				{
+					throw FbCppException(
+						"NULL value encountered but variant does not contain std::monostate at index " +
+						std::to_string(index));
+				}
+			}
+
+			return getVariantValue<V>(index, descriptor);
+		}
+
+	private:
+		const Descriptor& getDescriptor(unsigned index)
+		{
+			const auto& descs = getDescriptors();
+
+			if (index >= descs.size())
+				throw std::out_of_range("index out of range");
+
+			return descs[index];
+		}
+
+		template <typename T, std::size_t... Is>
+		T getStruct(std::index_sequence<Is...>)
+		{
+			using namespace impl::reflection;
+
+			return T{getStructField<FieldType<T, Is>>(static_cast<unsigned>(Is))...};
+		}
+
+		template <typename F>
+		auto getStructField(unsigned index)
+		{
+			using namespace impl::reflection;
+
+			if constexpr (isOptionalV<F>)
+				return get<F>(index);
+			else if constexpr (isVariantV<F>)
+				return get<F>(index);
+			else
+			{
+				auto opt = get<std::optional<F>>(index);
+
+				if (!opt.has_value())
+				{
+					throw FbCppException(
+						"Null value encountered for non-optional field at index " + std::to_string(index));
+				}
+
+				return std::move(opt.value());
+			}
+		}
+
+		template <typename T, std::size_t... Is>
+		T getTuple(std::index_sequence<Is...>)
+		{
+			using namespace impl::reflection;
+
+			return T{getStructField<std::tuple_element_t<Is, T>>(static_cast<unsigned>(Is))...};
+		}
+
+		template <typename V>
+		V getVariantValue(unsigned index, const Descriptor& descriptor)
+		{
+			using namespace impl::reflection;
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::BOOLEAN:
+					if constexpr (variantContainsV<bool, V>)
+						return V{get<std::optional<bool>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::INT16:
+					if (descriptor.scale != 0)
+					{
+						if constexpr (variantContainsV<ScaledInt16, V>)
+							return V{get<std::optional<ScaledInt16>>(index).value()};
+						if constexpr (variantContainsV<ScaledInt32, V>)
+							return V{get<std::optional<ScaledInt32>>(index).value()};
+						if constexpr (variantContainsV<ScaledInt64, V>)
+							return V{get<std::optional<ScaledInt64>>(index).value()};
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+						if constexpr (variantContainsV<ScaledBoostInt128, V>)
+							return V{get<std::optional<ScaledBoostInt128>>(index).value()};
+#endif
+					}
+					if constexpr (variantContainsV<std::int16_t, V>)
+						return V{get<std::optional<std::int16_t>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::INT32:
+					if (descriptor.scale != 0)
+					{
+						if constexpr (variantContainsV<ScaledInt32, V>)
+							return V{get<std::optional<ScaledInt32>>(index).value()};
+						if constexpr (variantContainsV<ScaledInt64, V>)
+							return V{get<std::optional<ScaledInt64>>(index).value()};
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+						if constexpr (variantContainsV<ScaledBoostInt128, V>)
+							return V{get<std::optional<ScaledBoostInt128>>(index).value()};
+#endif
+					}
+					if constexpr (variantContainsV<std::int32_t, V>)
+						return V{get<std::optional<std::int32_t>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::INT64:
+					if (descriptor.scale != 0)
+					{
+						if constexpr (variantContainsV<ScaledInt64, V>)
+							return V{get<std::optional<ScaledInt64>>(index).value()};
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+						if constexpr (variantContainsV<ScaledBoostInt128, V>)
+							return V{get<std::optional<ScaledBoostInt128>>(index).value()};
+#endif
+					}
+					if constexpr (variantContainsV<std::int64_t, V>)
+						return V{get<std::optional<std::int64_t>>(index).value()};
+					break;
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+				case DescriptorAdjustedType::INT128:
+					if constexpr (variantContainsV<ScaledOpaqueInt128, V>)
+						return V{get<std::optional<ScaledOpaqueInt128>>(index).value()};
+					else if (descriptor.scale != 0)
+					{
+						if constexpr (variantContainsV<ScaledBoostInt128, V>)
+							return V{get<std::optional<ScaledBoostInt128>>(index).value()};
+					}
+					else if constexpr (variantContainsV<BoostInt128, V>)
+						return V{get<std::optional<BoostInt128>>(index).value()};
+					break;
+#endif
+
+				case DescriptorAdjustedType::FLOAT:
+					if constexpr (variantContainsV<float, V>)
+						return V{get<std::optional<float>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::DOUBLE:
+					if constexpr (variantContainsV<double, V>)
+						return V{get<std::optional<double>>(index).value()};
+					break;
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+				case DescriptorAdjustedType::DECFLOAT16:
+					if constexpr (variantContainsV<OpaqueDecFloat16, V>)
+						return V{get<std::optional<OpaqueDecFloat16>>(index).value()};
+					else if constexpr (variantContainsV<BoostDecFloat16, V>)
+						return V{get<std::optional<BoostDecFloat16>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::DECFLOAT34:
+					if constexpr (variantContainsV<OpaqueDecFloat34, V>)
+						return V{get<std::optional<OpaqueDecFloat34>>(index).value()};
+					else if constexpr (variantContainsV<BoostDecFloat34, V>)
+						return V{get<std::optional<BoostDecFloat34>>(index).value()};
+					break;
+#endif
+
+				case DescriptorAdjustedType::STRING:
+					if constexpr (variantContainsV<std::string, V>)
+						return V{get<std::optional<std::string>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::DATE:
+					if constexpr (variantContainsV<OpaqueDate, V>)
+						return V{get<std::optional<OpaqueDate>>(index).value()};
+					else if constexpr (variantContainsV<Date, V>)
+						return V{get<std::optional<Date>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::TIME:
+					if constexpr (variantContainsV<OpaqueTime, V>)
+						return V{get<std::optional<OpaqueTime>>(index).value()};
+					else if constexpr (variantContainsV<Time, V>)
+						return V{get<std::optional<Time>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::TIMESTAMP:
+					if constexpr (variantContainsV<OpaqueTimestamp, V>)
+						return V{get<std::optional<OpaqueTimestamp>>(index).value()};
+					else if constexpr (variantContainsV<Timestamp, V>)
+						return V{get<std::optional<Timestamp>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::TIME_TZ:
+					if constexpr (variantContainsV<OpaqueTimeTz, V>)
+						return V{get<std::optional<OpaqueTimeTz>>(index).value()};
+					else if constexpr (variantContainsV<TimeTz, V>)
+						return V{get<std::optional<TimeTz>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::TIMESTAMP_TZ:
+					if constexpr (variantContainsV<OpaqueTimestampTz, V>)
+						return V{get<std::optional<OpaqueTimestampTz>>(index).value()};
+					else if constexpr (variantContainsV<TimestampTz, V>)
+						return V{get<std::optional<TimestampTz>>(index).value()};
+					break;
+
+				case DescriptorAdjustedType::BLOB:
+					if constexpr (variantContainsV<BlobId, V>)
+						return V{get<std::optional<BlobId>>(index).value()};
+					break;
+
+				default:
+					break;
+			}
+
+			return tryVariantAlternatives<V, 0>(index, descriptor);
+		}
+
+		template <typename V, std::size_t I = 0>
+		V tryVariantAlternatives(unsigned index, [[maybe_unused]] const Descriptor& descriptor)
+		{
+			using namespace impl::reflection;
+
+			if constexpr (I >= std::variant_size_v<V>)
+			{
+				throw FbCppException(
+					"Cannot convert SQL type to any variant alternative at index " + std::to_string(index));
+			}
+			else
+			{
+				using Alt = std::variant_alternative_t<I, V>;
+
+				if constexpr (std::is_same_v<Alt, std::monostate>)
+					return tryVariantAlternatives<V, I + 1>(index, descriptor);
+				else if constexpr (isOpaqueTypeV<Alt>)
+					return tryVariantAlternatives<V, I + 1>(index, descriptor);
+				else
+				{
+					auto opt = get<std::optional<Alt>>(index);
+					return V{std::move(opt.value())};
+				}
+			}
+		}
+
+		// FIXME: floating to integral
+		template <typename T>
+		std::optional<T> getNumber(unsigned index, std::optional<int>& scale, const char* typeName)
+		{
+			const auto& descriptor = getDescriptor(index);
+
+			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
+				return std::nullopt;
+
+			auto data = &message[descriptor.offset];
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+			std::optional<BoostInt128> boostInt128;
+			std::optional<BoostDecFloat16> boostDecFloat16;
+			std::optional<BoostDecFloat34> boostDecFloat34;
+#endif
+
+			// FIXME: Use IUtil
+			switch (descriptor.adjustedType)
+			{
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+				case DescriptorAdjustedType::INT128:
+					boostInt128.emplace(
+						getNumericConverter().opaqueInt128ToBoostInt128(*reinterpret_cast<const OpaqueInt128*>(data)));
+					data = reinterpret_cast<const std::byte*>(&boostInt128.value());
+					break;
+
+				case DescriptorAdjustedType::DECFLOAT16:
+					boostDecFloat16.emplace(getNumericConverter().opaqueDecFloat16ToBoostDecFloat16(
+						*reinterpret_cast<const OpaqueDecFloat16*>(data)));
+					data = reinterpret_cast<const std::byte*>(&boostDecFloat16.value());
+					break;
+
+				case DescriptorAdjustedType::DECFLOAT34:
+					boostDecFloat34.emplace(getNumericConverter().opaqueDecFloat34ToBoostDecFloat34(
+						*reinterpret_cast<const OpaqueDecFloat34*>(data)));
+					data = reinterpret_cast<const std::byte*>(&boostDecFloat34.value());
+					break;
+#endif
+
+				default:
+					break;
+			}
+
+			return convertNumber<T>(descriptor, data, scale, typeName);
+		}
+
+		[[noreturn]] static void throwInvalidType(const char* actualType, DescriptorAdjustedType descriptorType)
+		{
+			throw FbCppException("Invalid type: actual type " + std::string(actualType) + ", descriptor type " +
+				std::to_string(static_cast<unsigned>(descriptorType)));
+		}
+
+		template <typename T>
+		T convertNumber(
+			const Descriptor& descriptor, const std::byte* data, std::optional<int>& toScale, const char* toTypeName)
+		{
+			if (!toScale.has_value())
+			{
+				switch (descriptor.adjustedType)
+				{
+					case DescriptorAdjustedType::DECFLOAT16:
+					case DescriptorAdjustedType::DECFLOAT34:
+					case DescriptorAdjustedType::FLOAT:
+					case DescriptorAdjustedType::DOUBLE:
+						throwInvalidType(toTypeName, descriptor.adjustedType);
+
+					default:
+						break;
+				}
+
+				toScale = descriptor.scale;
+			}
+
+			switch (descriptor.adjustedType)
+			{
+				case DescriptorAdjustedType::INT16:
+					return getNumericConverter().numberToNumber<T>(
+						ScaledInt16{*reinterpret_cast<const std::int16_t*>(data), descriptor.scale}, toScale.value());
+
+				case DescriptorAdjustedType::INT32:
+					return getNumericConverter().numberToNumber<T>(
+						ScaledInt32{*reinterpret_cast<const std::int32_t*>(data), descriptor.scale}, toScale.value());
+
+				case DescriptorAdjustedType::INT64:
+					return getNumericConverter().numberToNumber<T>(
+						ScaledInt64{*reinterpret_cast<const std::int64_t*>(data), descriptor.scale}, toScale.value());
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+				case DescriptorAdjustedType::INT128:
+					return getNumericConverter().numberToNumber<T>(
+						ScaledBoostInt128{*reinterpret_cast<const BoostInt128*>(data), descriptor.scale},
+						toScale.value());
+
+				case DescriptorAdjustedType::DECFLOAT16:
+					return getNumericConverter().numberToNumber<T>(
+						*reinterpret_cast<const BoostDecFloat16*>(data), toScale.value());
+
+				case DescriptorAdjustedType::DECFLOAT34:
+					return getNumericConverter().numberToNumber<T>(
+						*reinterpret_cast<const BoostDecFloat34*>(data), toScale.value());
+#endif
+
+				case DescriptorAdjustedType::FLOAT:
+					return getNumericConverter().numberToNumber<T>(
+						*reinterpret_cast<const float*>(data), toScale.value());
+
+				case DescriptorAdjustedType::DOUBLE:
+					return getNumericConverter().numberToNumber<T>(
+						*reinterpret_cast<const double*>(data), toScale.value());
+
+				default:
+					throwInvalidType(toTypeName, descriptor.adjustedType);
+			}
+		}
+
+	private:
+		const std::byte* message = nullptr;
+		const std::vector<Descriptor>* descriptors = nullptr;
+		impl::NumericConverter* numericConverter = nullptr;
+		impl::CalendarConverter* calendarConverter = nullptr;
+
+		const std::vector<Descriptor>& getDescriptors() const
+		{
+			return *descriptors;
+		}
+
+		impl::NumericConverter& getNumericConverter() const
+		{
+			return *numericConverter;
+		}
+
+		impl::CalendarConverter& getCalendarConverter() const
+		{
+			return *calendarConverter;
+		}
+	};
+
+	///
+	/// @name Row convenience template specializations
+	/// @{
+	///
+
+	template <>
+	inline std::optional<bool> Row::get<std::optional<bool>>(unsigned index)
+	{
+		return getBool(index);
+	}
+
+	template <>
+	inline std::optional<BlobId> Row::get<std::optional<BlobId>>(unsigned index)
+	{
+		return getBlobId(index);
+	}
+
+	template <>
+	inline std::optional<std::int16_t> Row::get<std::optional<std::int16_t>>(unsigned index)
+	{
+		return getInt16(index);
+	}
+
+	template <>
+	inline std::optional<ScaledInt16> Row::get<std::optional<ScaledInt16>>(unsigned index)
+	{
+		return getScaledInt16(index);
+	}
+
+	template <>
+	inline std::optional<std::int32_t> Row::get<std::optional<std::int32_t>>(unsigned index)
+	{
+		return getInt32(index);
+	}
+
+	template <>
+	inline std::optional<ScaledInt32> Row::get<std::optional<ScaledInt32>>(unsigned index)
+	{
+		return getScaledInt32(index);
+	}
+
+	template <>
+	inline std::optional<std::int64_t> Row::get<std::optional<std::int64_t>>(unsigned index)
+	{
+		return getInt64(index);
+	}
+
+	template <>
+	inline std::optional<ScaledInt64> Row::get<std::optional<ScaledInt64>>(unsigned index)
+	{
+		return getScaledInt64(index);
+	}
+
+	template <>
+	inline std::optional<ScaledOpaqueInt128> Row::get<std::optional<ScaledOpaqueInt128>>(unsigned index)
+	{
+		return getScaledOpaqueInt128(index);
+	}
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+	template <>
+	inline std::optional<BoostInt128> Row::get<std::optional<BoostInt128>>(unsigned index)
+	{
+		return getBoostInt128(index);
+	}
+
+	template <>
+	inline std::optional<ScaledBoostInt128> Row::get<std::optional<ScaledBoostInt128>>(unsigned index)
+	{
+		return getScaledBoostInt128(index);
+	}
+#endif
+
+	template <>
+	inline std::optional<float> Row::get<std::optional<float>>(unsigned index)
+	{
+		return getFloat(index);
+	}
+
+	template <>
+	inline std::optional<double> Row::get<std::optional<double>>(unsigned index)
+	{
+		return getDouble(index);
+	}
+
+	template <>
+	inline std::optional<OpaqueDecFloat16> Row::get<std::optional<OpaqueDecFloat16>>(unsigned index)
+	{
+		return getOpaqueDecFloat16(index);
+	}
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+	template <>
+	inline std::optional<BoostDecFloat16> Row::get<std::optional<BoostDecFloat16>>(unsigned index)
+	{
+		return getBoostDecFloat16(index);
+	}
+#endif
+
+	template <>
+	inline std::optional<OpaqueDecFloat34> Row::get<std::optional<OpaqueDecFloat34>>(unsigned index)
+	{
+		return getOpaqueDecFloat34(index);
+	}
+
+#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
+	template <>
+	inline std::optional<BoostDecFloat34> Row::get<std::optional<BoostDecFloat34>>(unsigned index)
+	{
+		return getBoostDecFloat34(index);
+	}
+#endif
+
+	template <>
+	inline std::optional<Date> Row::get<std::optional<Date>>(unsigned index)
+	{
+		return getDate(index);
+	}
+
+	template <>
+	inline std::optional<OpaqueDate> Row::get<std::optional<OpaqueDate>>(unsigned index)
+	{
+		return getOpaqueDate(index);
+	}
+
+	template <>
+	inline std::optional<Time> Row::get<std::optional<Time>>(unsigned index)
+	{
+		return getTime(index);
+	}
+
+	template <>
+	inline std::optional<OpaqueTime> Row::get<std::optional<OpaqueTime>>(unsigned index)
+	{
+		return getOpaqueTime(index);
+	}
+
+	template <>
+	inline std::optional<OpaqueTimestamp> Row::get<std::optional<OpaqueTimestamp>>(unsigned index)
+	{
+		return getOpaqueTimestamp(index);
+	}
+
+	template <>
+	inline std::optional<Timestamp> Row::get<std::optional<Timestamp>>(unsigned index)
+	{
+		return getTimestamp(index);
+	}
+
+	template <>
+	inline std::optional<TimeTz> Row::get<std::optional<TimeTz>>(unsigned index)
+	{
+		return getTimeTz(index);
+	}
+
+	template <>
+	inline std::optional<OpaqueTimeTz> Row::get<std::optional<OpaqueTimeTz>>(unsigned index)
+	{
+		return getOpaqueTimeTz(index);
+	}
+
+	template <>
+	inline std::optional<TimestampTz> Row::get<std::optional<TimestampTz>>(unsigned index)
+	{
+		return getTimestampTz(index);
+	}
+
+	template <>
+	inline std::optional<OpaqueTimestampTz> Row::get<std::optional<OpaqueTimestampTz>>(unsigned index)
+	{
+		return getOpaqueTimestampTz(index);
+	}
+
+	template <>
+	inline std::optional<std::string> Row::get<std::optional<std::string>>(unsigned index)
+	{
+		return getString(index);
+	}
+
+	///
+	/// @}
+	///
+}  // namespace fbcpp
+
+
+#endif  // FBCPP_ROW_H

--- a/src/fb-cpp/Row.h
+++ b/src/fb-cpp/Row.h
@@ -73,9 +73,9 @@ namespace fbcpp
 		/// @param message Span over the raw row data.
 		///
 		Row(Client& client, const std::vector<Descriptor>& descriptors, std::span<const std::byte> message)
-			: message{message},
+			: client{&client},
 			  descriptors{&descriptors},
-			  client{&client},
+			  message{message},
 			  statusWrapper{client},
 			  numericConverter{client},
 			  calendarConverter{client}
@@ -1017,9 +1017,9 @@ namespace fbcpp
 		}
 
 	private:
+		Client* client;
+		const std::vector<Descriptor>* descriptors;
 		std::span<const std::byte> message;
-		const std::vector<Descriptor>* descriptors = nullptr;
-		Client* client = nullptr;
 		impl::StatusWrapper statusWrapper;
 		impl::NumericConverter numericConverter;
 		impl::CalendarConverter calendarConverter;

--- a/src/fb-cpp/Row.h
+++ b/src/fb-cpp/Row.h
@@ -39,6 +39,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -69,9 +70,9 @@ namespace fbcpp
 		///
 		/// @param client Client used to build conversion helpers.
 		/// @param descriptors Column descriptors.
-		/// @param message Pointer to the raw row data.
+		/// @param message Span over the raw row data.
 		///
-		Row(Client& client, const std::vector<Descriptor>& descriptors, const std::byte* message)
+		Row(Client& client, const std::vector<Descriptor>& descriptors, std::span<const std::byte> message)
 			: message{message},
 			  descriptors{&descriptors},
 			  client{&client},
@@ -1016,7 +1017,7 @@ namespace fbcpp
 		}
 
 	private:
-		const std::byte* message = nullptr;
+		std::span<const std::byte> message;
 		const std::vector<Descriptor>* descriptors = nullptr;
 		Client* client = nullptr;
 		impl::StatusWrapper statusWrapper;

--- a/src/fb-cpp/Row.h
+++ b/src/fb-cpp/Row.h
@@ -64,24 +64,20 @@ namespace fbcpp
 	class Row final
 	{
 	public:
-		Row() = default;
-
 		///
 		/// @brief Constructs a Row view over the given message buffer.
 		///
-		/// @param message Pointer to the raw row data.
+		/// @param client Client used to build conversion helpers.
 		/// @param descriptors Column descriptors.
-		/// @param statusWrapper Status wrapper used for Firebird conversions.
-		/// @param numericConverter Numeric converter.
-		/// @param calendarConverter Calendar converter.
+		/// @param message Pointer to the raw row data.
 		///
-		Row(const std::byte* message, const std::vector<Descriptor>& descriptors, impl::StatusWrapper& statusWrapper,
-			impl::NumericConverter& numericConverter, impl::CalendarConverter& calendarConverter)
+		Row(Client& client, const std::vector<Descriptor>& descriptors, const std::byte* message)
 			: message{message},
 			  descriptors{&descriptors},
-			  statusWrapper{&statusWrapper},
-			  numericConverter{&numericConverter},
-			  calendarConverter{&calendarConverter}
+			  client{&client},
+			  statusWrapper{client},
+			  numericConverter{client},
+			  calendarConverter{client}
 		{
 		}
 
@@ -313,7 +309,7 @@ namespace fbcpp
 			switch (descriptor.adjustedType)
 			{
 				case DescriptorAdjustedType::DATE:
-					return getCalendarConverter().opaqueDateToDate(
+					return calendarConverter.opaqueDateToDate(
 						*reinterpret_cast<const OpaqueDate*>(&message[descriptor.offset]));
 
 				default:
@@ -354,7 +350,7 @@ namespace fbcpp
 			switch (descriptor.adjustedType)
 			{
 				case DescriptorAdjustedType::TIME:
-					return getCalendarConverter().opaqueTimeToTime(
+					return calendarConverter.opaqueTimeToTime(
 						*reinterpret_cast<const OpaqueTime*>(&message[descriptor.offset]));
 
 				default:
@@ -395,7 +391,7 @@ namespace fbcpp
 			switch (descriptor.adjustedType)
 			{
 				case DescriptorAdjustedType::TIMESTAMP:
-					return getCalendarConverter().opaqueTimestampToTimestamp(
+					return calendarConverter.opaqueTimestampToTimestamp(
 						*reinterpret_cast<const OpaqueTimestamp*>(&message[descriptor.offset]));
 
 				default:
@@ -436,8 +432,8 @@ namespace fbcpp
 			switch (descriptor.adjustedType)
 			{
 				case DescriptorAdjustedType::TIME_TZ:
-					return getCalendarConverter().opaqueTimeTzToTimeTz(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueTimeTz*>(&message[descriptor.offset]));
+					return calendarConverter.opaqueTimeTzToTimeTz(
+						&statusWrapper, *reinterpret_cast<const OpaqueTimeTz*>(&message[descriptor.offset]));
 
 				default:
 					throwInvalidType("TimeTz", descriptor.adjustedType);
@@ -477,8 +473,8 @@ namespace fbcpp
 			switch (descriptor.adjustedType)
 			{
 				case DescriptorAdjustedType::TIMESTAMP_TZ:
-					return getCalendarConverter().opaqueTimestampTzToTimestampTz(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueTimestampTz*>(&message[descriptor.offset]));
+					return calendarConverter.opaqueTimestampTzToTimestampTz(
+						&statusWrapper, *reinterpret_cast<const OpaqueTimestampTz*>(&message[descriptor.offset]));
 
 				default:
 					throwInvalidType("TimestampTz", descriptor.adjustedType);
@@ -547,52 +543,51 @@ namespace fbcpp
 					return (message[descriptor.offset] != std::byte{0}) ? std::string{"true"} : std::string{"false"};
 
 				case DescriptorAdjustedType::INT16:
-					return getNumericConverter().numberToString(
+					return numericConverter.numberToString(
 						ScaledInt16{*reinterpret_cast<const std::int16_t*>(data), descriptor.scale});
 
 				case DescriptorAdjustedType::INT32:
-					return getNumericConverter().numberToString(
+					return numericConverter.numberToString(
 						ScaledInt32{*reinterpret_cast<const std::int32_t*>(data), descriptor.scale});
 
 				case DescriptorAdjustedType::INT64:
-					return getNumericConverter().numberToString(
+					return numericConverter.numberToString(
 						ScaledInt64{*reinterpret_cast<const std::int64_t*>(data), descriptor.scale});
 
 				case DescriptorAdjustedType::INT128:
-					return getNumericConverter().opaqueInt128ToString(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueInt128*>(data), descriptor.scale);
+					return numericConverter.opaqueInt128ToString(
+						&statusWrapper, *reinterpret_cast<const OpaqueInt128*>(data), descriptor.scale);
 
 				case DescriptorAdjustedType::FLOAT:
-					return getNumericConverter().numberToString(*reinterpret_cast<const float*>(data));
+					return numericConverter.numberToString(*reinterpret_cast<const float*>(data));
 
 				case DescriptorAdjustedType::DOUBLE:
-					return getNumericConverter().numberToString(*reinterpret_cast<const double*>(data));
+					return numericConverter.numberToString(*reinterpret_cast<const double*>(data));
 
 				case DescriptorAdjustedType::DATE:
-					return getCalendarConverter().opaqueDateToString(*reinterpret_cast<const OpaqueDate*>(data));
+					return calendarConverter.opaqueDateToString(*reinterpret_cast<const OpaqueDate*>(data));
 
 				case DescriptorAdjustedType::TIME:
-					return getCalendarConverter().opaqueTimeToString(*reinterpret_cast<const OpaqueTime*>(data));
+					return calendarConverter.opaqueTimeToString(*reinterpret_cast<const OpaqueTime*>(data));
 
 				case DescriptorAdjustedType::TIMESTAMP:
-					return getCalendarConverter().opaqueTimestampToString(
-						*reinterpret_cast<const OpaqueTimestamp*>(data));
+					return calendarConverter.opaqueTimestampToString(*reinterpret_cast<const OpaqueTimestamp*>(data));
 
 				case DescriptorAdjustedType::TIME_TZ:
-					return getCalendarConverter().opaqueTimeTzToString(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueTimeTz*>(data));
+					return calendarConverter.opaqueTimeTzToString(
+						&statusWrapper, *reinterpret_cast<const OpaqueTimeTz*>(data));
 
 				case DescriptorAdjustedType::TIMESTAMP_TZ:
-					return getCalendarConverter().opaqueTimestampTzToString(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueTimestampTz*>(data));
+					return calendarConverter.opaqueTimestampTzToString(
+						&statusWrapper, *reinterpret_cast<const OpaqueTimestampTz*>(data));
 
 				case DescriptorAdjustedType::DECFLOAT16:
-					return getNumericConverter().opaqueDecFloat16ToString(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueDecFloat16*>(data));
+					return numericConverter.opaqueDecFloat16ToString(
+						&statusWrapper, *reinterpret_cast<const OpaqueDecFloat16*>(data));
 
 				case DescriptorAdjustedType::DECFLOAT34:
-					return getNumericConverter().opaqueDecFloat34ToString(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueDecFloat34*>(data));
+					return numericConverter.opaqueDecFloat34ToString(
+						&statusWrapper, *reinterpret_cast<const OpaqueDecFloat34*>(data));
 
 				case DescriptorAdjustedType::STRING:
 					return std::string{reinterpret_cast<const char*>(data + sizeof(std::uint16_t)),
@@ -623,10 +618,10 @@ namespace fbcpp
 
 			constexpr std::size_t N = fieldCountV<T>;
 
-			if (N != getDescriptors().size())
+			if (N != descriptors->size())
 			{
 				throw FbCppException("Struct field count (" + std::to_string(N) +
-					") does not match output column count (" + std::to_string(getDescriptors().size()) + ")");
+					") does not match output column count (" + std::to_string(descriptors->size()) + ")");
 			}
 
 			return getStruct<T>(std::make_index_sequence<N>{});
@@ -642,10 +637,10 @@ namespace fbcpp
 
 			constexpr std::size_t N = std::tuple_size_v<T>;
 
-			if (N != getDescriptors().size())
+			if (N != descriptors->size())
 			{
 				throw FbCppException("Tuple element count (" + std::to_string(N) +
-					") does not match output column count (" + std::to_string(getDescriptors().size()) + ")");
+					") does not match output column count (" + std::to_string(descriptors->size()) + ")");
 			}
 
 			return getTuple<T>(std::make_index_sequence<N>{});
@@ -684,12 +679,10 @@ namespace fbcpp
 	private:
 		const Descriptor& getDescriptor(unsigned index)
 		{
-			const auto& descs = getDescriptors();
-
-			if (index >= descs.size())
+			if (index >= descriptors->size())
 				throw std::out_of_range("index out of range");
 
-			return descs[index];
+			return (*descriptors)[index];
 		}
 
 		template <typename T, std::size_t... Is>
@@ -931,19 +924,19 @@ namespace fbcpp
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
 				case DescriptorAdjustedType::INT128:
 					boostInt128.emplace(
-						getNumericConverter().opaqueInt128ToBoostInt128(*reinterpret_cast<const OpaqueInt128*>(data)));
+						numericConverter.opaqueInt128ToBoostInt128(*reinterpret_cast<const OpaqueInt128*>(data)));
 					data = reinterpret_cast<const std::byte*>(&boostInt128.value());
 					break;
 
 				case DescriptorAdjustedType::DECFLOAT16:
-					boostDecFloat16.emplace(getNumericConverter().opaqueDecFloat16ToBoostDecFloat16(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueDecFloat16*>(data)));
+					boostDecFloat16.emplace(numericConverter.opaqueDecFloat16ToBoostDecFloat16(
+						&statusWrapper, *reinterpret_cast<const OpaqueDecFloat16*>(data)));
 					data = reinterpret_cast<const std::byte*>(&boostDecFloat16.value());
 					break;
 
 				case DescriptorAdjustedType::DECFLOAT34:
-					boostDecFloat34.emplace(getNumericConverter().opaqueDecFloat34ToBoostDecFloat34(
-						getStatusWrapper(), *reinterpret_cast<const OpaqueDecFloat34*>(data)));
+					boostDecFloat34.emplace(numericConverter.opaqueDecFloat34ToBoostDecFloat34(
+						&statusWrapper, *reinterpret_cast<const OpaqueDecFloat34*>(data)));
 					data = reinterpret_cast<const std::byte*>(&boostDecFloat34.value());
 					break;
 #endif
@@ -985,39 +978,37 @@ namespace fbcpp
 			switch (descriptor.adjustedType)
 			{
 				case DescriptorAdjustedType::INT16:
-					return getNumericConverter().numberToNumber<T>(
+					return numericConverter.numberToNumber<T>(
 						ScaledInt16{*reinterpret_cast<const std::int16_t*>(data), descriptor.scale}, toScale.value());
 
 				case DescriptorAdjustedType::INT32:
-					return getNumericConverter().numberToNumber<T>(
+					return numericConverter.numberToNumber<T>(
 						ScaledInt32{*reinterpret_cast<const std::int32_t*>(data), descriptor.scale}, toScale.value());
 
 				case DescriptorAdjustedType::INT64:
-					return getNumericConverter().numberToNumber<T>(
+					return numericConverter.numberToNumber<T>(
 						ScaledInt64{*reinterpret_cast<const std::int64_t*>(data), descriptor.scale}, toScale.value());
 
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
 				case DescriptorAdjustedType::INT128:
-					return getNumericConverter().numberToNumber<T>(
+					return numericConverter.numberToNumber<T>(
 						ScaledBoostInt128{*reinterpret_cast<const BoostInt128*>(data), descriptor.scale},
 						toScale.value());
 
 				case DescriptorAdjustedType::DECFLOAT16:
-					return getNumericConverter().numberToNumber<T>(
+					return numericConverter.numberToNumber<T>(
 						*reinterpret_cast<const BoostDecFloat16*>(data), toScale.value());
 
 				case DescriptorAdjustedType::DECFLOAT34:
-					return getNumericConverter().numberToNumber<T>(
+					return numericConverter.numberToNumber<T>(
 						*reinterpret_cast<const BoostDecFloat34*>(data), toScale.value());
 #endif
 
 				case DescriptorAdjustedType::FLOAT:
-					return getNumericConverter().numberToNumber<T>(
-						*reinterpret_cast<const float*>(data), toScale.value());
+					return numericConverter.numberToNumber<T>(*reinterpret_cast<const float*>(data), toScale.value());
 
 				case DescriptorAdjustedType::DOUBLE:
-					return getNumericConverter().numberToNumber<T>(
-						*reinterpret_cast<const double*>(data), toScale.value());
+					return numericConverter.numberToNumber<T>(*reinterpret_cast<const double*>(data), toScale.value());
 
 				default:
 					throwInvalidType(toTypeName, descriptor.adjustedType);
@@ -1027,29 +1018,10 @@ namespace fbcpp
 	private:
 		const std::byte* message = nullptr;
 		const std::vector<Descriptor>* descriptors = nullptr;
-		impl::StatusWrapper* statusWrapper = nullptr;
-		impl::NumericConverter* numericConverter = nullptr;
-		impl::CalendarConverter* calendarConverter = nullptr;
-
-		impl::StatusWrapper* getStatusWrapper() const
-		{
-			return statusWrapper;
-		}
-
-		const std::vector<Descriptor>& getDescriptors() const
-		{
-			return *descriptors;
-		}
-
-		impl::NumericConverter& getNumericConverter() const
-		{
-			return *numericConverter;
-		}
-
-		impl::CalendarConverter& getCalendarConverter() const
-		{
-			return *calendarConverter;
-		}
+		Client* client = nullptr;
+		impl::StatusWrapper statusWrapper;
+		impl::NumericConverter numericConverter;
+		impl::CalendarConverter calendarConverter;
 	};
 
 	///

--- a/src/fb-cpp/RowSet.cpp
+++ b/src/fb-cpp/RowSet.cpp
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) 2025 Adriano dos Santos Fernandes
+ * Copyright (c) 2026 F.D.Castel
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,17 +22,41 @@
  * SOFTWARE.
  */
 
-#ifndef FBCPP_H
-#define FBCPP_H
-
-#include "Client.h"
-#include "Attachment.h"
-#include "Transaction.h"
-#include "Descriptor.h"
-#include "Statement.h"
 #include "RowSet.h"
-#include "Batch.h"
-#include "Blob.h"
-#include "EventListener.h"
+#include "Client.h"
+#include "Statement.h"
 
-#endif  // FBCPP_H
+using namespace fbcpp;
+using namespace fbcpp::impl;
+
+
+RowSet::RowSet(Statement& statement, unsigned maxRows)
+	: status{statement.getAttachment().getClient().newStatus()},
+	  statusWrapper{statement.getAttachment().getClient(), status.get()},
+	  numericConverter{statement.getAttachment().getClient(), &statusWrapper},
+	  calendarConverter{statement.getAttachment().getClient(), &statusWrapper}
+{
+	assert(statement.isValid());
+	assert(statement.getResultSetHandle());
+
+	descriptors = statement.getOutputDescriptors();
+
+	auto outMetadata = statement.getOutputMetadata();
+	messageLength = outMetadata->getMessageLength(&statusWrapper);
+
+	buffer.resize(static_cast<std::size_t>(maxRows) * messageLength);
+
+	auto resultSet = statement.getResultSetHandle();
+	auto* dest = buffer.data();
+
+	for (unsigned i = 0; i < maxRows; ++i)
+	{
+		if (resultSet->fetchNext(&statusWrapper, dest) != fb::IStatus::RESULT_OK)
+			break;
+
+		dest += messageLength;
+		++count;
+	}
+
+	buffer.resize(static_cast<std::size_t>(dest - buffer.data()));
+}

--- a/src/fb-cpp/RowSet.cpp
+++ b/src/fb-cpp/RowSet.cpp
@@ -31,8 +31,7 @@ using namespace fbcpp::impl;
 
 
 RowSet::RowSet(Statement& statement, unsigned maxRows)
-	: status{statement.getAttachment().getClient().newStatus()},
-	  statusWrapper{statement.getAttachment().getClient(), status.get()},
+	: statusWrapper{statement.getAttachment().getClient()},
 	  numericConverter{statement.getAttachment().getClient(), &statusWrapper},
 	  calendarConverter{statement.getAttachment().getClient(), &statusWrapper}
 {

--- a/src/fb-cpp/RowSet.cpp
+++ b/src/fb-cpp/RowSet.cpp
@@ -31,7 +31,8 @@ using namespace fbcpp::impl;
 
 
 RowSet::RowSet(Statement& statement, unsigned maxRows)
-	: statusWrapper{statement.getAttachment().getClient()},
+	: client{&statement.getAttachment().getClient()},
+	  statusWrapper{statement.getAttachment().getClient()},
 	  numericConverter{statement.getAttachment().getClient()},
 	  calendarConverter{statement.getAttachment().getClient()}
 {

--- a/src/fb-cpp/RowSet.cpp
+++ b/src/fb-cpp/RowSet.cpp
@@ -32,8 +32,8 @@ using namespace fbcpp::impl;
 
 RowSet::RowSet(Statement& statement, unsigned maxRows)
 	: statusWrapper{statement.getAttachment().getClient()},
-	  numericConverter{statement.getAttachment().getClient(), &statusWrapper},
-	  calendarConverter{statement.getAttachment().getClient(), &statusWrapper}
+	  numericConverter{statement.getAttachment().getClient()},
+	  calendarConverter{statement.getAttachment().getClient()}
 {
 	assert(statement.isValid());
 	assert(statement.getResultSetHandle());

--- a/src/fb-cpp/RowSet.h
+++ b/src/fb-cpp/RowSet.h
@@ -70,7 +70,8 @@ namespace fbcpp
 		explicit RowSet(Statement& statement, unsigned maxRows);
 
 		RowSet(RowSet&& o) noexcept
-			: count{o.count},
+			: client{o.client},
+			  count{o.count},
 			  messageLength{o.messageLength},
 			  buffer{std::move(o.buffer)},
 			  descriptors{std::move(o.descriptors)},
@@ -86,6 +87,7 @@ namespace fbcpp
 		{
 			if (this != &o)
 			{
+				client = o.client;
 				count = o.count;
 				messageLength = o.messageLength;
 				buffer = std::move(o.buffer);
@@ -128,7 +130,7 @@ namespace fbcpp
 		{
 			assert(index < count);
 			const auto* data = buffer.data() + static_cast<std::size_t>(index) * messageLength;
-			return Row{data, descriptors, statusWrapper, numericConverter, calendarConverter};
+			return Row{*client, descriptors, data};
 		}
 
 		///
@@ -151,6 +153,7 @@ namespace fbcpp
 		}
 
 	private:
+		Client* client = nullptr;
 		unsigned count = 0;
 		unsigned messageLength = 0;
 		std::vector<std::byte> buffer;

--- a/src/fb-cpp/RowSet.h
+++ b/src/fb-cpp/RowSet.h
@@ -152,7 +152,7 @@ namespace fbcpp
 		}
 
 	private:
-		Client* client = nullptr;
+		Client* client;
 		unsigned count = 0;
 		unsigned messageLength = 0;
 		std::vector<std::byte> buffer;

--- a/src/fb-cpp/RowSet.h
+++ b/src/fb-cpp/RowSet.h
@@ -129,8 +129,7 @@ namespace fbcpp
 		Row getRow(unsigned index)
 		{
 			assert(index < count);
-			const auto* data = buffer.data() + static_cast<std::size_t>(index) * messageLength;
-			return Row{*client, descriptors, data};
+			return Row{*client, descriptors, getRawRow(index)};
 		}
 
 		///

--- a/src/fb-cpp/RowSet.h
+++ b/src/fb-cpp/RowSet.h
@@ -74,7 +74,6 @@ namespace fbcpp
 			  messageLength{o.messageLength},
 			  buffer{std::move(o.buffer)},
 			  descriptors{std::move(o.descriptors)},
-			  status{std::move(o.status)},
 			  statusWrapper{std::move(o.statusWrapper)},
 			  numericConverter{std::move(o.numericConverter)},
 			  calendarConverter{std::move(o.calendarConverter)}
@@ -91,7 +90,6 @@ namespace fbcpp
 				messageLength = o.messageLength;
 				buffer = std::move(o.buffer);
 				descriptors = std::move(o.descriptors);
-				status = std::move(o.status);
 				statusWrapper = std::move(o.statusWrapper);
 				numericConverter = std::move(o.numericConverter);
 				calendarConverter = std::move(o.calendarConverter);
@@ -157,7 +155,6 @@ namespace fbcpp
 		unsigned messageLength = 0;
 		std::vector<std::byte> buffer;
 		std::vector<Descriptor> descriptors;
-		FbUniquePtr<Firebird::IStatus> status;
 		impl::StatusWrapper statusWrapper;
 		impl::NumericConverter numericConverter;
 		impl::CalendarConverter calendarConverter;

--- a/src/fb-cpp/RowSet.h
+++ b/src/fb-cpp/RowSet.h
@@ -128,7 +128,7 @@ namespace fbcpp
 		{
 			assert(index < count);
 			const auto* data = buffer.data() + static_cast<std::size_t>(index) * messageLength;
-			return Row{data, descriptors, numericConverter, calendarConverter};
+			return Row{data, descriptors, statusWrapper, numericConverter, calendarConverter};
 		}
 
 		///

--- a/src/fb-cpp/RowSet.h
+++ b/src/fb-cpp/RowSet.h
@@ -1,0 +1,167 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 F.D.Castel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FBCPP_ROWSET_H
+#define FBCPP_ROWSET_H
+
+#include "fb-api.h"
+#include "Row.h"
+#include "SmartPtrs.h"
+#include "NumericConverter.h"
+#include "CalendarConverter.h"
+#include "Descriptor.h"
+#include "Exception.h"
+#include <cassert>
+#include <cstddef>
+#include <span>
+#include <vector>
+
+
+///
+/// fb-cpp namespace.
+///
+namespace fbcpp
+{
+	class Statement;
+
+	///
+	/// @brief A disconnected buffer of rows fetched from a Statement's result set.
+	///
+	/// Rows are fetched into a contiguous buffer at construction time. After
+	/// construction the RowSet is independent of its source Statement and can
+	/// be used, moved, or destroyed freely.
+	///
+	class RowSet final
+	{
+
+	public:
+		///
+		/// @brief Fetches up to `maxRows` rows from the current result set of
+		/// `statement`.
+		///
+		/// The statement must have an open result set (i.e. `execute()` was
+		/// called and it is a SELECT-type statement). Rows are fetched via
+		/// `IResultSet::fetchNext()` directly into the internal buffer.
+		///
+		/// @param statement The statement with an open result set.
+		/// @param maxRows Maximum number of rows to fetch.
+		///
+		explicit RowSet(Statement& statement, unsigned maxRows);
+
+		RowSet(RowSet&& o) noexcept
+			: count{o.count},
+			  messageLength{o.messageLength},
+			  buffer{std::move(o.buffer)},
+			  descriptors{std::move(o.descriptors)},
+			  status{std::move(o.status)},
+			  statusWrapper{std::move(o.statusWrapper)},
+			  numericConverter{std::move(o.numericConverter)},
+			  calendarConverter{std::move(o.calendarConverter)}
+		{
+			o.count = 0;
+			o.messageLength = 0;
+		}
+
+		RowSet& operator=(RowSet&& o) noexcept
+		{
+			if (this != &o)
+			{
+				count = o.count;
+				messageLength = o.messageLength;
+				buffer = std::move(o.buffer);
+				descriptors = std::move(o.descriptors);
+				status = std::move(o.status);
+				statusWrapper = std::move(o.statusWrapper);
+				numericConverter = std::move(o.numericConverter);
+				calendarConverter = std::move(o.calendarConverter);
+				o.count = 0;
+				o.messageLength = 0;
+			}
+
+			return *this;
+		}
+
+		RowSet(const RowSet&) = delete;
+		RowSet& operator=(const RowSet&) = delete;
+
+	public:
+		///
+		/// @brief Returns the number of rows actually fetched.
+		///
+		unsigned getCount() const noexcept
+		{
+			return count;
+		}
+
+		///
+		/// @brief Returns the message length (in bytes) of each row.
+		///
+		unsigned getMessageLength() const noexcept
+		{
+			return messageLength;
+		}
+
+		///
+		/// @brief Returns a Row view for typed access to the row at `index`.
+		/// @param index Zero-based row index (must be < getCount()).
+		///
+		Row getRow(unsigned index)
+		{
+			assert(index < count);
+			const auto* data = buffer.data() + static_cast<std::size_t>(index) * messageLength;
+			return Row{data, descriptors, numericConverter, calendarConverter};
+		}
+
+		///
+		/// @brief Returns a span over the raw data of the row at `index`.
+		/// @param index Zero-based row index (must be < getCount()).
+		///
+		std::span<const std::byte> getRawRow(unsigned index) const
+		{
+			assert(index < count);
+			const auto* data = buffer.data() + static_cast<std::size_t>(index) * messageLength;
+			return {data, messageLength};
+		}
+
+		///
+		/// @brief Returns the entire contiguous buffer containing all fetched rows.
+		///
+		const std::vector<std::byte>& getRawBuffer() const noexcept
+		{
+			return buffer;
+		}
+
+	private:
+		unsigned count = 0;
+		unsigned messageLength = 0;
+		std::vector<std::byte> buffer;
+		std::vector<Descriptor> descriptors;
+		FbUniquePtr<Firebird::IStatus> status;
+		impl::StatusWrapper statusWrapper;
+		impl::NumericConverter numericConverter;
+		impl::CalendarConverter calendarConverter;
+	};
+}  // namespace fbcpp
+
+#endif  // FBCPP_ROWSET_H

--- a/src/fb-cpp/Statement.cpp
+++ b/src/fb-cpp/Statement.cpp
@@ -34,8 +34,7 @@ using namespace fbcpp::impl;
 Statement::Statement(
 	Attachment& attachment, Transaction& transaction, std::string_view sql, const StatementOptions& options)
 	: attachment{&attachment},
-	  status{attachment.getClient().newStatus()},
-	  statusWrapper{attachment.getClient(), status.get()},
+	  statusWrapper{attachment.getClient()},
 	  calendarConverter{attachment.getClient(), &statusWrapper},
 	  numericConverter{attachment.getClient(), &statusWrapper}
 {

--- a/src/fb-cpp/Statement.cpp
+++ b/src/fb-cpp/Statement.cpp
@@ -178,6 +178,8 @@ Statement::Statement(
 
 	outMetadata.reset(statementHandle->getOutputMetadata(&statusWrapper));
 	processMetadata(outMetadata, outDescriptors, outMessage);
+
+	outRow = Row(outMessage.data(), outDescriptors, numericConverter, calendarConverter);
 }
 
 void Statement::free()

--- a/src/fb-cpp/Statement.cpp
+++ b/src/fb-cpp/Statement.cpp
@@ -178,7 +178,7 @@ Statement::Statement(
 	outMetadata.reset(statementHandle->getOutputMetadata(&statusWrapper));
 	processMetadata(outMetadata, outDescriptors, outMessage);
 
-	outRow = Row(outMessage.data(), outDescriptors, statusWrapper, numericConverter, calendarConverter);
+	outRow = std::make_unique<Row>(attachment.getClient(), outDescriptors, outMessage.data());
 }
 
 void Statement::free()

--- a/src/fb-cpp/Statement.cpp
+++ b/src/fb-cpp/Statement.cpp
@@ -35,8 +35,8 @@ Statement::Statement(
 	Attachment& attachment, Transaction& transaction, std::string_view sql, const StatementOptions& options)
 	: attachment{&attachment},
 	  statusWrapper{attachment.getClient()},
-	  calendarConverter{attachment.getClient(), &statusWrapper},
-	  numericConverter{attachment.getClient(), &statusWrapper}
+	  calendarConverter{attachment.getClient()},
+	  numericConverter{attachment.getClient()}
 {
 	assert(attachment.isValid());
 	assert(transaction.isValid());
@@ -178,7 +178,7 @@ Statement::Statement(
 	outMetadata.reset(statementHandle->getOutputMetadata(&statusWrapper));
 	processMetadata(outMetadata, outDescriptors, outMessage);
 
-	outRow = Row(outMessage.data(), outDescriptors, numericConverter, calendarConverter);
+	outRow = Row(outMessage.data(), outDescriptors, statusWrapper, numericConverter, calendarConverter);
 }
 
 void Statement::free()

--- a/src/fb-cpp/Statement.cpp
+++ b/src/fb-cpp/Statement.cpp
@@ -178,7 +178,7 @@ Statement::Statement(
 	outMetadata.reset(statementHandle->getOutputMetadata(&statusWrapper));
 	processMetadata(outMetadata, outDescriptors, outMessage);
 
-	outRow = std::make_unique<Row>(attachment.getClient(), outDescriptors, outMessage.data());
+	outRow = std::make_unique<Row>(attachment.getClient(), outDescriptors, std::span{outMessage});
 }
 
 void Statement::free()

--- a/src/fb-cpp/Statement.h
+++ b/src/fb-cpp/Statement.h
@@ -287,10 +287,11 @@ namespace fbcpp
 			  outMetadata{std::move(o.outMetadata)},
 			  outDescriptors{std::move(o.outDescriptors)},
 			  outMessage{std::move(o.outMessage)},
-			  outRow{outMessage.data(), outDescriptors, statusWrapper, numericConverter, calendarConverter},
+			  outRow{std::make_unique<Row>(attachment->getClient(), outDescriptors, outMessage.data())},
 			  type{o.type},
 			  cursorFlags{o.cursorFlags}
 		{
+			o.outRow.reset();
 		}
 
 		///
@@ -315,9 +316,11 @@ namespace fbcpp
 				outMetadata = std::move(o.outMetadata);
 				outDescriptors = std::move(o.outDescriptors);
 				outMessage = std::move(o.outMessage);
-				outRow = Row(outMessage.data(), outDescriptors, statusWrapper, numericConverter, calendarConverter);
+				outRow = std::make_unique<Row>(attachment->getClient(), outDescriptors, outMessage.data());
 				type = o.type;
 				cursorFlags = o.cursorFlags;
+
+				o.outRow.reset();
 			}
 
 			return *this;
@@ -1611,7 +1614,7 @@ namespace fbcpp
 		bool isNull(unsigned index)
 		{
 			assert(isValid());
-			return outRow.isNull(index);
+			return outRow->isNull(index);
 		}
 
 		///
@@ -1620,7 +1623,7 @@ namespace fbcpp
 		std::optional<bool> getBool(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getBool(index);
+			return outRow->getBool(index);
 		}
 
 		///
@@ -1629,7 +1632,7 @@ namespace fbcpp
 		std::optional<std::int16_t> getInt16(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getInt16(index);
+			return outRow->getInt16(index);
 		}
 
 		///
@@ -1638,7 +1641,7 @@ namespace fbcpp
 		std::optional<ScaledInt16> getScaledInt16(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getScaledInt16(index);
+			return outRow->getScaledInt16(index);
 		}
 
 		///
@@ -1647,7 +1650,7 @@ namespace fbcpp
 		std::optional<std::int32_t> getInt32(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getInt32(index);
+			return outRow->getInt32(index);
 		}
 
 		///
@@ -1656,7 +1659,7 @@ namespace fbcpp
 		std::optional<ScaledInt32> getScaledInt32(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getScaledInt32(index);
+			return outRow->getScaledInt32(index);
 		}
 
 		///
@@ -1665,7 +1668,7 @@ namespace fbcpp
 		std::optional<std::int64_t> getInt64(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getInt64(index);
+			return outRow->getInt64(index);
 		}
 
 		///
@@ -1674,7 +1677,7 @@ namespace fbcpp
 		std::optional<ScaledInt64> getScaledInt64(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getScaledInt64(index);
+			return outRow->getScaledInt64(index);
 		}
 
 		///
@@ -1683,7 +1686,7 @@ namespace fbcpp
 		std::optional<ScaledOpaqueInt128> getScaledOpaqueInt128(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getScaledOpaqueInt128(index);
+			return outRow->getScaledOpaqueInt128(index);
 		}
 
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
@@ -1693,7 +1696,7 @@ namespace fbcpp
 		std::optional<BoostInt128> getBoostInt128(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getBoostInt128(index);
+			return outRow->getBoostInt128(index);
 		}
 
 		///
@@ -1702,7 +1705,7 @@ namespace fbcpp
 		std::optional<ScaledBoostInt128> getScaledBoostInt128(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getScaledBoostInt128(index);
+			return outRow->getScaledBoostInt128(index);
 		}
 #endif
 
@@ -1712,7 +1715,7 @@ namespace fbcpp
 		std::optional<float> getFloat(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getFloat(index);
+			return outRow->getFloat(index);
 		}
 
 		///
@@ -1721,7 +1724,7 @@ namespace fbcpp
 		std::optional<double> getDouble(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getDouble(index);
+			return outRow->getDouble(index);
 		}
 
 		///
@@ -1730,7 +1733,7 @@ namespace fbcpp
 		std::optional<OpaqueDecFloat16> getOpaqueDecFloat16(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getOpaqueDecFloat16(index);
+			return outRow->getOpaqueDecFloat16(index);
 		}
 
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
@@ -1740,7 +1743,7 @@ namespace fbcpp
 		std::optional<BoostDecFloat16> getBoostDecFloat16(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getBoostDecFloat16(index);
+			return outRow->getBoostDecFloat16(index);
 		}
 #endif
 
@@ -1750,7 +1753,7 @@ namespace fbcpp
 		std::optional<OpaqueDecFloat34> getOpaqueDecFloat34(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getOpaqueDecFloat34(index);
+			return outRow->getOpaqueDecFloat34(index);
 		}
 
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
@@ -1760,7 +1763,7 @@ namespace fbcpp
 		std::optional<BoostDecFloat34> getBoostDecFloat34(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getBoostDecFloat34(index);
+			return outRow->getBoostDecFloat34(index);
 		}
 #endif
 
@@ -1770,7 +1773,7 @@ namespace fbcpp
 		std::optional<Date> getDate(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getDate(index);
+			return outRow->getDate(index);
 		}
 
 		///
@@ -1779,7 +1782,7 @@ namespace fbcpp
 		std::optional<OpaqueDate> getOpaqueDate(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getOpaqueDate(index);
+			return outRow->getOpaqueDate(index);
 		}
 
 		///
@@ -1788,7 +1791,7 @@ namespace fbcpp
 		std::optional<Time> getTime(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getTime(index);
+			return outRow->getTime(index);
 		}
 
 		///
@@ -1797,7 +1800,7 @@ namespace fbcpp
 		std::optional<OpaqueTime> getOpaqueTime(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getOpaqueTime(index);
+			return outRow->getOpaqueTime(index);
 		}
 
 		///
@@ -1806,7 +1809,7 @@ namespace fbcpp
 		std::optional<Timestamp> getTimestamp(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getTimestamp(index);
+			return outRow->getTimestamp(index);
 		}
 
 		///
@@ -1815,7 +1818,7 @@ namespace fbcpp
 		std::optional<OpaqueTimestamp> getOpaqueTimestamp(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getOpaqueTimestamp(index);
+			return outRow->getOpaqueTimestamp(index);
 		}
 
 		///
@@ -1824,7 +1827,7 @@ namespace fbcpp
 		std::optional<TimeTz> getTimeTz(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getTimeTz(index);
+			return outRow->getTimeTz(index);
 		}
 
 		///
@@ -1833,7 +1836,7 @@ namespace fbcpp
 		std::optional<OpaqueTimeTz> getOpaqueTimeTz(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getOpaqueTimeTz(index);
+			return outRow->getOpaqueTimeTz(index);
 		}
 
 		///
@@ -1842,7 +1845,7 @@ namespace fbcpp
 		std::optional<TimestampTz> getTimestampTz(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getTimestampTz(index);
+			return outRow->getTimestampTz(index);
 		}
 
 		///
@@ -1851,7 +1854,7 @@ namespace fbcpp
 		std::optional<OpaqueTimestampTz> getOpaqueTimestampTz(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getOpaqueTimestampTz(index);
+			return outRow->getOpaqueTimestampTz(index);
 		}
 
 		///
@@ -1860,7 +1863,7 @@ namespace fbcpp
 		std::optional<BlobId> getBlobId(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getBlobId(index);
+			return outRow->getBlobId(index);
 		}
 
 		///
@@ -1869,7 +1872,7 @@ namespace fbcpp
 		std::optional<std::string> getString(unsigned index)
 		{
 			assert(isValid());
-			return outRow.getString(index);
+			return outRow->getString(index);
 		}
 
 		///
@@ -1883,7 +1886,7 @@ namespace fbcpp
 		T get(unsigned index)
 		{
 			assert(isValid());
-			return outRow.get<T>(index);
+			return outRow->get<T>(index);
 		}
 
 		///
@@ -1897,7 +1900,7 @@ namespace fbcpp
 		T get()
 		{
 			assert(isValid());
-			return outRow.get<T>();
+			return outRow->get<T>();
 		}
 
 		///
@@ -1933,7 +1936,7 @@ namespace fbcpp
 		T get()
 		{
 			assert(isValid());
-			return outRow.get<T>();
+			return outRow->get<T>();
 		}
 
 		///
@@ -1968,7 +1971,7 @@ namespace fbcpp
 		V get(unsigned index)
 		{
 			assert(isValid());
-			return outRow.get<V>(index);
+			return outRow->get<V>(index);
 		}
 
 		///
@@ -2201,7 +2204,7 @@ namespace fbcpp
 		FbRef<fb::IMessageMetadata> outMetadata;
 		std::vector<Descriptor> outDescriptors;
 		std::vector<std::byte> outMessage;
-		Row outRow;
+		std::unique_ptr<Row> outRow;
 		StatementType type;
 		unsigned cursorFlags = 0;
 	};

--- a/src/fb-cpp/Statement.h
+++ b/src/fb-cpp/Statement.h
@@ -287,7 +287,7 @@ namespace fbcpp
 			  outMetadata{std::move(o.outMetadata)},
 			  outDescriptors{std::move(o.outDescriptors)},
 			  outMessage{std::move(o.outMessage)},
-			  outRow{std::make_unique<Row>(attachment->getClient(), outDescriptors, outMessage.data())},
+			  outRow{std::make_unique<Row>(attachment->getClient(), outDescriptors, std::span{outMessage})},
 			  type{o.type},
 			  cursorFlags{o.cursorFlags}
 		{
@@ -316,7 +316,7 @@ namespace fbcpp
 				outMetadata = std::move(o.outMetadata);
 				outDescriptors = std::move(o.outDescriptors);
 				outMessage = std::move(o.outMessage);
-				outRow = std::make_unique<Row>(attachment->getClient(), outDescriptors, outMessage.data());
+				outRow = std::make_unique<Row>(attachment->getClient(), outDescriptors, std::span{outMessage});
 				type = o.type;
 				cursorFlags = o.cursorFlags;
 

--- a/src/fb-cpp/Statement.h
+++ b/src/fb-cpp/Statement.h
@@ -287,7 +287,7 @@ namespace fbcpp
 			  outMetadata{std::move(o.outMetadata)},
 			  outDescriptors{std::move(o.outDescriptors)},
 			  outMessage{std::move(o.outMessage)},
-			  outRow{outMessage.data(), outDescriptors, numericConverter, calendarConverter},
+			  outRow{outMessage.data(), outDescriptors, statusWrapper, numericConverter, calendarConverter},
 			  type{o.type},
 			  cursorFlags{o.cursorFlags}
 		{
@@ -315,7 +315,7 @@ namespace fbcpp
 				outMetadata = std::move(o.outMetadata);
 				outDescriptors = std::move(o.outDescriptors);
 				outMessage = std::move(o.outMessage);
-				outRow = Row(outMessage.data(), outDescriptors, numericConverter, calendarConverter);
+				outRow = Row(outMessage.data(), outDescriptors, statusWrapper, numericConverter, calendarConverter);
 				type = o.type;
 				cursorFlags = o.cursorFlags;
 			}
@@ -1050,7 +1050,7 @@ namespace fbcpp
 			{
 				case DescriptorAdjustedType::TIME_TZ:
 					*reinterpret_cast<OpaqueTimeTz*>(&message[descriptor.offset]) =
-						calendarConverter.timeTzToOpaqueTimeTz(value);
+						calendarConverter.timeTzToOpaqueTimeTz(&statusWrapper, value);
 					break;
 
 				default:
@@ -1111,7 +1111,7 @@ namespace fbcpp
 			{
 				case DescriptorAdjustedType::TIMESTAMP_TZ:
 					*reinterpret_cast<OpaqueTimestampTz*>(&message[descriptor.offset]) =
-						calendarConverter.timestampTzToOpaqueTimestampTz(value);
+						calendarConverter.timestampTzToOpaqueTimestampTz(&statusWrapper, value);
 					break;
 
 				default:
@@ -1259,11 +1259,13 @@ namespace fbcpp
 					break;
 
 				case DescriptorAdjustedType::TIME_TZ:
-					*reinterpret_cast<OpaqueTimeTz*>(data) = calendarConverter.stringToOpaqueTimeTz(value);
+					*reinterpret_cast<OpaqueTimeTz*>(data) =
+						calendarConverter.stringToOpaqueTimeTz(&statusWrapper, value);
 					break;
 
 				case DescriptorAdjustedType::TIMESTAMP_TZ:
-					*reinterpret_cast<OpaqueTimestampTz*>(data) = calendarConverter.stringToOpaqueTimestampTz(value);
+					*reinterpret_cast<OpaqueTimestampTz*>(data) =
+						calendarConverter.stringToOpaqueTimestampTz(&statusWrapper, value);
 					break;
 
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
@@ -2095,7 +2097,7 @@ namespace fbcpp
 					const auto boostDecFloat16 = convertNumber<BoostDecFloat16>(
 						valueDescriptor, valueAddress, descriptorScale, "BoostDecFloat16");
 					*reinterpret_cast<OpaqueDecFloat16*>(descriptorData) =
-						numericConverter.boostDecFloat16ToOpaqueDecFloat16(boostDecFloat16);
+						numericConverter.boostDecFloat16ToOpaqueDecFloat16(&statusWrapper, boostDecFloat16);
 					break;
 				}
 
@@ -2104,7 +2106,7 @@ namespace fbcpp
 					const auto boostDecFloat34 = convertNumber<BoostDecFloat34>(
 						valueDescriptor, valueAddress, descriptorScale, "BoostDecFloat34");
 					*reinterpret_cast<OpaqueDecFloat34*>(descriptorData) =
-						numericConverter.boostDecFloat34ToOpaqueDecFloat34(boostDecFloat34);
+						numericConverter.boostDecFloat34ToOpaqueDecFloat34(&statusWrapper, boostDecFloat34);
 					break;
 				}
 #endif

--- a/src/fb-cpp/Statement.h
+++ b/src/fb-cpp/Statement.h
@@ -276,7 +276,6 @@ namespace fbcpp
 		///
 		Statement(Statement&& o) noexcept
 			: attachment{o.attachment},
-			  status{std::move(o.status)},
 			  statusWrapper{std::move(o.statusWrapper)},
 			  calendarConverter{std::move(o.calendarConverter)},
 			  numericConverter{std::move(o.numericConverter)},
@@ -305,7 +304,6 @@ namespace fbcpp
 			if (this != &o)
 			{
 				attachment = o.attachment;
-				status = std::move(o.status);
 				statusWrapper = std::move(o.statusWrapper);
 				calendarConverter = std::move(o.calendarConverter);
 				numericConverter = std::move(o.numericConverter);
@@ -2190,7 +2188,6 @@ namespace fbcpp
 
 	private:
 		Attachment* attachment;
-		FbUniquePtr<Firebird::IStatus> status;
 		impl::StatusWrapper statusWrapper;
 		impl::CalendarConverter calendarConverter;
 		impl::NumericConverter numericConverter;

--- a/src/fb-cpp/Statement.h
+++ b/src/fb-cpp/Statement.h
@@ -31,6 +31,7 @@
 #include "Blob.h"
 #include "Attachment.h"
 #include "Client.h"
+#include "Row.h"
 #include "NumericConverter.h"
 #include "CalendarConverter.h"
 #include "Descriptor.h"
@@ -287,6 +288,7 @@ namespace fbcpp
 			  outMetadata{std::move(o.outMetadata)},
 			  outDescriptors{std::move(o.outDescriptors)},
 			  outMessage{std::move(o.outMessage)},
+			  outRow{outMessage.data(), outDescriptors, numericConverter, calendarConverter},
 			  type{o.type},
 			  cursorFlags{o.cursorFlags}
 		{
@@ -315,6 +317,7 @@ namespace fbcpp
 				outMetadata = std::move(o.outMetadata);
 				outDescriptors = std::move(o.outDescriptors);
 				outMessage = std::move(o.outMessage);
+				outRow = Row(outMessage.data(), outDescriptors, numericConverter, calendarConverter);
 				type = o.type;
 				cursorFlags = o.cursorFlags;
 			}
@@ -1608,11 +1611,7 @@ namespace fbcpp
 		bool isNull(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			return *reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE;
+			return outRow.isNull(index);
 		}
 
 		///
@@ -1621,21 +1620,7 @@ namespace fbcpp
 		std::optional<bool> getBool(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::BOOLEAN:
-					return message[descriptor.offset] != std::byte{0};
-
-				default:
-					throwInvalidType("bool", descriptor.adjustedType);
-			}
+			return outRow.getBool(index);
 		}
 
 		///
@@ -1643,8 +1628,8 @@ namespace fbcpp
 		///
 		std::optional<std::int16_t> getInt16(unsigned index)
 		{
-			std::optional<int> scale{0};
-			return getNumber<std::int16_t>(index, scale, "std::int16_t");
+			assert(isValid());
+			return outRow.getInt16(index);
 		}
 
 		///
@@ -1652,9 +1637,8 @@ namespace fbcpp
 		///
 		std::optional<ScaledInt16> getScaledInt16(unsigned index)
 		{
-			std::optional<int> scale;
-			const auto value = getNumber<std::int16_t>(index, scale, "ScaledInt16");
-			return value.has_value() ? std::optional{ScaledInt16{value.value(), scale.value()}} : std::nullopt;
+			assert(isValid());
+			return outRow.getScaledInt16(index);
 		}
 
 		///
@@ -1662,8 +1646,8 @@ namespace fbcpp
 		///
 		std::optional<std::int32_t> getInt32(unsigned index)
 		{
-			std::optional<int> scale{0};
-			return getNumber<std::int32_t>(index, scale, "std::int32_t");
+			assert(isValid());
+			return outRow.getInt32(index);
 		}
 
 		///
@@ -1671,9 +1655,8 @@ namespace fbcpp
 		///
 		std::optional<ScaledInt32> getScaledInt32(unsigned index)
 		{
-			std::optional<int> scale;
-			const auto value = getNumber<std::int32_t>(index, scale, "ScaledInt32");
-			return value.has_value() ? std::optional{ScaledInt32{value.value(), scale.value()}} : std::nullopt;
+			assert(isValid());
+			return outRow.getScaledInt32(index);
 		}
 
 		///
@@ -1681,8 +1664,8 @@ namespace fbcpp
 		///
 		std::optional<std::int64_t> getInt64(unsigned index)
 		{
-			std::optional<int> scale{0};
-			return getNumber<std::int64_t>(index, scale, "std::int64_t");
+			assert(isValid());
+			return outRow.getInt64(index);
 		}
 
 		///
@@ -1690,9 +1673,8 @@ namespace fbcpp
 		///
 		std::optional<ScaledInt64> getScaledInt64(unsigned index)
 		{
-			std::optional<int> scale;
-			const auto value = getNumber<std::int64_t>(index, scale, "ScaledInt64");
-			return value.has_value() ? std::optional{ScaledInt64{value.value(), scale.value()}} : std::nullopt;
+			assert(isValid());
+			return outRow.getScaledInt64(index);
 		}
 
 		///
@@ -1701,23 +1683,7 @@ namespace fbcpp
 		std::optional<ScaledOpaqueInt128> getScaledOpaqueInt128(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::INT128:
-					return ScaledOpaqueInt128{
-						OpaqueInt128{*reinterpret_cast<const OpaqueInt128*>(&message[descriptor.offset])},
-						descriptor.scale};
-
-				default:
-					throwInvalidType("ScaledOpaqueInt128", descriptor.adjustedType);
-			}
+			return outRow.getScaledOpaqueInt128(index);
 		}
 
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
@@ -1726,9 +1692,8 @@ namespace fbcpp
 		///
 		std::optional<BoostInt128> getBoostInt128(unsigned index)
 		{
-			std::optional<int> scale{0};
-			const auto value = getNumber<BoostInt128>(index, scale, "BoostInt128");
-			return value.has_value() ? std::optional{value.value()} : std::nullopt;
+			assert(isValid());
+			return outRow.getBoostInt128(index);
 		}
 
 		///
@@ -1736,9 +1701,8 @@ namespace fbcpp
 		///
 		std::optional<ScaledBoostInt128> getScaledBoostInt128(unsigned index)
 		{
-			std::optional<int> scale;
-			const auto value = getNumber<BoostInt128>(index, scale, "ScaledBoostInt128");
-			return value.has_value() ? std::optional{ScaledBoostInt128{value.value(), scale.value()}} : std::nullopt;
+			assert(isValid());
+			return outRow.getScaledBoostInt128(index);
 		}
 #endif
 
@@ -1747,8 +1711,8 @@ namespace fbcpp
 		///
 		std::optional<float> getFloat(unsigned index)
 		{
-			std::optional<int> scale{0};
-			return getNumber<float>(index, scale, "float");
+			assert(isValid());
+			return outRow.getFloat(index);
 		}
 
 		///
@@ -1756,8 +1720,8 @@ namespace fbcpp
 		///
 		std::optional<double> getDouble(unsigned index)
 		{
-			std::optional<int> scale{0};
-			return getNumber<double>(index, scale, "double");
+			assert(isValid());
+			return outRow.getDouble(index);
 		}
 
 		///
@@ -1766,21 +1730,7 @@ namespace fbcpp
 		std::optional<OpaqueDecFloat16> getOpaqueDecFloat16(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::DECFLOAT16:
-					return OpaqueDecFloat16{*reinterpret_cast<const OpaqueDecFloat16*>(&message[descriptor.offset])};
-
-				default:
-					throwInvalidType("OpaqueDecFloat16", descriptor.adjustedType);
-			}
+			return outRow.getOpaqueDecFloat16(index);
 		}
 
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
@@ -1789,8 +1739,8 @@ namespace fbcpp
 		///
 		std::optional<BoostDecFloat16> getBoostDecFloat16(unsigned index)
 		{
-			std::optional<int> scale{0};
-			return getNumber<BoostDecFloat16>(index, scale, "BoostDecFloat16");
+			assert(isValid());
+			return outRow.getBoostDecFloat16(index);
 		}
 #endif
 
@@ -1800,21 +1750,7 @@ namespace fbcpp
 		std::optional<OpaqueDecFloat34> getOpaqueDecFloat34(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::DECFLOAT34:
-					return OpaqueDecFloat34{*reinterpret_cast<const OpaqueDecFloat34*>(&message[descriptor.offset])};
-
-				default:
-					throwInvalidType("OpaqueDecFloat34", descriptor.adjustedType);
-			}
+			return outRow.getOpaqueDecFloat34(index);
 		}
 
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
@@ -1823,8 +1759,8 @@ namespace fbcpp
 		///
 		std::optional<BoostDecFloat34> getBoostDecFloat34(unsigned index)
 		{
-			std::optional<int> scale{0};
-			return getNumber<BoostDecFloat34>(index, scale, "BoostDecFloat34");
+			assert(isValid());
+			return outRow.getBoostDecFloat34(index);
 		}
 #endif
 
@@ -1834,22 +1770,7 @@ namespace fbcpp
 		std::optional<Date> getDate(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::DATE:
-					return calendarConverter.opaqueDateToDate(
-						*reinterpret_cast<const OpaqueDate*>(&message[descriptor.offset]));
-
-				default:
-					throwInvalidType("Date", descriptor.adjustedType);
-			}
+			return outRow.getDate(index);
 		}
 
 		///
@@ -1858,21 +1779,7 @@ namespace fbcpp
 		std::optional<OpaqueDate> getOpaqueDate(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::DATE:
-					return OpaqueDate{*reinterpret_cast<const OpaqueDate*>(&message[descriptor.offset])};
-
-				default:
-					throwInvalidType("OpaqueDate", descriptor.adjustedType);
-			}
+			return outRow.getOpaqueDate(index);
 		}
 
 		///
@@ -1881,22 +1788,7 @@ namespace fbcpp
 		std::optional<Time> getTime(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::TIME:
-					return calendarConverter.opaqueTimeToTime(
-						*reinterpret_cast<const OpaqueTime*>(&message[descriptor.offset]));
-
-				default:
-					throwInvalidType("Time", descriptor.adjustedType);
-			}
+			return outRow.getTime(index);
 		}
 
 		///
@@ -1905,21 +1797,7 @@ namespace fbcpp
 		std::optional<OpaqueTime> getOpaqueTime(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::TIME:
-					return OpaqueTime{*reinterpret_cast<const OpaqueTime*>(&message[descriptor.offset])};
-
-				default:
-					throwInvalidType("OpaqueTime", descriptor.adjustedType);
-			}
+			return outRow.getOpaqueTime(index);
 		}
 
 		///
@@ -1928,22 +1806,7 @@ namespace fbcpp
 		std::optional<Timestamp> getTimestamp(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::TIMESTAMP:
-					return calendarConverter.opaqueTimestampToTimestamp(
-						*reinterpret_cast<const OpaqueTimestamp*>(&message[descriptor.offset]));
-
-				default:
-					throwInvalidType("Timestamp", descriptor.adjustedType);
-			}
+			return outRow.getTimestamp(index);
 		}
 
 		///
@@ -1952,21 +1815,7 @@ namespace fbcpp
 		std::optional<OpaqueTimestamp> getOpaqueTimestamp(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::TIMESTAMP:
-					return OpaqueTimestamp{*reinterpret_cast<const OpaqueTimestamp*>(&message[descriptor.offset])};
-
-				default:
-					throwInvalidType("OpaqueTimestamp", descriptor.adjustedType);
-			}
+			return outRow.getOpaqueTimestamp(index);
 		}
 
 		///
@@ -1975,22 +1824,7 @@ namespace fbcpp
 		std::optional<TimeTz> getTimeTz(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::TIME_TZ:
-					return calendarConverter.opaqueTimeTzToTimeTz(
-						*reinterpret_cast<const OpaqueTimeTz*>(&message[descriptor.offset]));
-
-				default:
-					throwInvalidType("TimeTz", descriptor.adjustedType);
-			}
+			return outRow.getTimeTz(index);
 		}
 
 		///
@@ -1999,21 +1833,7 @@ namespace fbcpp
 		std::optional<OpaqueTimeTz> getOpaqueTimeTz(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::TIME_TZ:
-					return OpaqueTimeTz{*reinterpret_cast<const OpaqueTimeTz*>(&message[descriptor.offset])};
-
-				default:
-					throwInvalidType("OpaqueTimeTz", descriptor.adjustedType);
-			}
+			return outRow.getOpaqueTimeTz(index);
 		}
 
 		///
@@ -2022,22 +1842,7 @@ namespace fbcpp
 		std::optional<TimestampTz> getTimestampTz(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::TIMESTAMP_TZ:
-					return calendarConverter.opaqueTimestampTzToTimestampTz(
-						*reinterpret_cast<const OpaqueTimestampTz*>(&message[descriptor.offset]));
-
-				default:
-					throwInvalidType("TimestampTz", descriptor.adjustedType);
-			}
+			return outRow.getTimestampTz(index);
 		}
 
 		///
@@ -2046,21 +1851,7 @@ namespace fbcpp
 		std::optional<OpaqueTimestampTz> getOpaqueTimestampTz(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::TIMESTAMP_TZ:
-					return OpaqueTimestampTz{*reinterpret_cast<const OpaqueTimestampTz*>(&message[descriptor.offset])};
-
-				default:
-					throwInvalidType("OpaqueTimestampTz", descriptor.adjustedType);
-			}
+			return outRow.getOpaqueTimestampTz(index);
 		}
 
 		///
@@ -2069,25 +1860,7 @@ namespace fbcpp
 		std::optional<BlobId> getBlobId(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::BLOB:
-				{
-					BlobId value;
-					value.id = *reinterpret_cast<const ISC_QUAD*>(&message[descriptor.offset]);
-					return value;
-				}
-
-				default:
-					throwInvalidType("BlobId", descriptor.adjustedType);
-			}
+			return outRow.getBlobId(index);
 		}
 
 		///
@@ -2096,71 +1869,7 @@ namespace fbcpp
 		std::optional<std::string> getString(unsigned index)
 		{
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			const auto data = &message[descriptor.offset];
-
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::BOOLEAN:
-					return (message[descriptor.offset] != std::byte{0}) ? std::string{"true"} : std::string{"false"};
-
-				case DescriptorAdjustedType::INT16:
-					return numericConverter.numberToString(
-						ScaledInt16{*reinterpret_cast<const std::int16_t*>(data), descriptor.scale});
-
-				case DescriptorAdjustedType::INT32:
-					return numericConverter.numberToString(
-						ScaledInt32{*reinterpret_cast<const std::int32_t*>(data), descriptor.scale});
-
-				case DescriptorAdjustedType::INT64:
-					return numericConverter.numberToString(
-						ScaledInt64{*reinterpret_cast<const std::int64_t*>(data), descriptor.scale});
-
-				case DescriptorAdjustedType::INT128:
-					return numericConverter.opaqueInt128ToString(
-						*reinterpret_cast<const OpaqueInt128*>(data), descriptor.scale);
-
-				case DescriptorAdjustedType::FLOAT:
-					return numericConverter.numberToString(*reinterpret_cast<const float*>(data));
-
-				case DescriptorAdjustedType::DOUBLE:
-					return numericConverter.numberToString(*reinterpret_cast<const double*>(data));
-
-				case DescriptorAdjustedType::DATE:
-					return calendarConverter.opaqueDateToString(*reinterpret_cast<const OpaqueDate*>(data));
-
-				case DescriptorAdjustedType::TIME:
-					return calendarConverter.opaqueTimeToString(*reinterpret_cast<const OpaqueTime*>(data));
-
-				case DescriptorAdjustedType::TIMESTAMP:
-					return calendarConverter.opaqueTimestampToString(*reinterpret_cast<const OpaqueTimestamp*>(data));
-
-				case DescriptorAdjustedType::TIME_TZ:
-					return calendarConverter.opaqueTimeTzToString(*reinterpret_cast<const OpaqueTimeTz*>(data));
-
-				case DescriptorAdjustedType::TIMESTAMP_TZ:
-					return calendarConverter.opaqueTimestampTzToString(
-						*reinterpret_cast<const OpaqueTimestampTz*>(data));
-
-				case DescriptorAdjustedType::DECFLOAT16:
-					return numericConverter.opaqueDecFloat16ToString(*reinterpret_cast<const OpaqueDecFloat16*>(data));
-
-				case DescriptorAdjustedType::DECFLOAT34:
-					return numericConverter.opaqueDecFloat34ToString(*reinterpret_cast<const OpaqueDecFloat34*>(data));
-
-				case DescriptorAdjustedType::STRING:
-					return std::string{reinterpret_cast<const char*>(data + sizeof(std::uint16_t)),
-						*reinterpret_cast<const std::uint16_t*>(data)};
-
-				default:
-					throwInvalidType("std::string", descriptor.adjustedType);
-			}
+			return outRow.getString(index);
 		}
 
 		///
@@ -2171,7 +1880,11 @@ namespace fbcpp
 		/// @brief Retrieves a column using the most appropriate typed accessor specialization.
 		///
 		template <typename T>
-		T get(unsigned index);
+		T get(unsigned index)
+		{
+			assert(isValid());
+			return outRow.get<T>(index);
+		}
 
 		///
 		/// @brief Retrieves all output columns into a user-defined aggregate struct.
@@ -2183,17 +1896,8 @@ namespace fbcpp
 		template <Aggregate T>
 		T get()
 		{
-			using namespace impl::reflection;
-
-			constexpr std::size_t N = fieldCountV<T>;
-
-			if (N != outDescriptors.size())
-			{
-				throw FbCppException("Struct field count (" + std::to_string(N) +
-					") does not match output column count (" + std::to_string(outDescriptors.size()) + ")");
-			}
-
-			return getStruct<T>(std::make_index_sequence<N>{});
+			assert(isValid());
+			return outRow.get<T>();
 		}
 
 		///
@@ -2228,17 +1932,8 @@ namespace fbcpp
 		template <TupleLike T>
 		T get()
 		{
-			using namespace impl::reflection;
-
-			constexpr std::size_t N = std::tuple_size_v<T>;
-
-			if (N != outDescriptors.size())
-			{
-				throw FbCppException("Tuple element count (" + std::to_string(N) +
-					") does not match output column count (" + std::to_string(outDescriptors.size()) + ")");
-			}
-
-			return getTuple<T>(std::make_index_sequence<N>{});
+			assert(isValid());
+			return outRow.get<T>();
 		}
 
 		///
@@ -2272,30 +1967,8 @@ namespace fbcpp
 		template <VariantLike V>
 		V get(unsigned index)
 		{
-			using namespace impl::reflection;
-
-			static_assert(variantAlternativesSupportedV<V>,
-				"Variant contains unsupported types. All variant alternatives must be types supported by fb-cpp "
-				"(e.g., std::int32_t, std::string, Date, ScaledOpaqueInt128, etc.). Check VariantTypeTraits.h for the "
-				"complete list of supported types.");
-
 			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-
-			if (isNull(index))
-			{
-				if constexpr (variantContainsV<std::monostate, V>)
-					return V{std::monostate{}};
-				else
-				{
-					throw FbCppException(
-						"NULL value encountered but variant does not contain std::monostate at index " +
-						std::to_string(index));
-				}
-			}
-
-			return getVariantValue<V>(index, descriptor);
+			return outRow.get<V>(index);
 		}
 
 		///
@@ -2340,54 +2013,6 @@ namespace fbcpp
 		}
 
 		///
-		/// @brief Validates and returns the descriptor for the given output column index.
-		///
-		const Descriptor& getOutDescriptor(unsigned index)
-		{
-			if (index >= outDescriptors.size())
-				throw std::out_of_range("index out of range");
-
-			return outDescriptors[index];
-		}
-
-		///
-		/// @brief Helper to retrieve all output columns into a struct.
-		///
-		template <typename T, std::size_t... Is>
-		T getStruct(std::index_sequence<Is...>)
-		{
-			using namespace impl::reflection;
-
-			return T{getStructField<FieldType<T, Is>>(static_cast<unsigned>(Is))...};
-		}
-
-		///
-		/// @brief Helper to get a single field value, throwing if NULL for non-optional fields.
-		///
-		template <typename F>
-		auto getStructField(unsigned index)
-		{
-			using namespace impl::reflection;
-
-			if constexpr (isOptionalV<F>)
-				return get<F>(index);
-			else if constexpr (isVariantV<F>)
-				return get<F>(index);
-			else
-			{
-				auto opt = get<std::optional<F>>(index);
-
-				if (!opt.has_value())
-				{
-					throw FbCppException(
-						"Null value encountered for non-optional field at index " + std::to_string(index));
-				}
-
-				return std::move(opt.value());
-			}
-		}
-
-		///
 		/// @brief Helper to set all input parameters from a struct.
 		///
 		template <typename T, std::size_t... Is>
@@ -2400,228 +2025,12 @@ namespace fbcpp
 		}
 
 		///
-		/// @brief Helper to retrieve all output columns into a tuple.
-		///
-		template <typename T, std::size_t... Is>
-		T getTuple(std::index_sequence<Is...>)
-		{
-			using namespace impl::reflection;
-
-			return T{getStructField<std::tuple_element_t<Is, T>>(static_cast<unsigned>(Is))...};
-		}
-
-		///
 		/// @brief Helper to set all input parameters from a tuple.
 		///
 		template <typename T, std::size_t... Is>
 		void setTuple(const T& value, std::index_sequence<Is...>)
 		{
 			(set(static_cast<unsigned>(Is), std::get<Is>(value)), ...);
-		}
-
-		///
-		/// @brief Helper to retrieve a column value as a variant.
-		/// Uses priority: exact type match first, then declaration order for conversions.
-		///
-		template <typename V>
-		V getVariantValue(unsigned index, const Descriptor& descriptor)
-		{
-			using namespace impl::reflection;
-
-			// Try exact type matches first based on SQL type
-			switch (descriptor.adjustedType)
-			{
-				case DescriptorAdjustedType::BOOLEAN:
-					if constexpr (variantContainsV<bool, V>)
-						return V{get<std::optional<bool>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::INT16:
-					if (descriptor.scale != 0)
-					{
-						// For scaled numbers, prefer exact scaled type, then larger scaled types
-						if constexpr (variantContainsV<ScaledInt16, V>)
-							return V{get<std::optional<ScaledInt16>>(index).value()};
-						if constexpr (variantContainsV<ScaledInt32, V>)
-							return V{get<std::optional<ScaledInt32>>(index).value()};
-						if constexpr (variantContainsV<ScaledInt64, V>)
-							return V{get<std::optional<ScaledInt64>>(index).value()};
-#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
-						if constexpr (variantContainsV<ScaledBoostInt128, V>)
-							return V{get<std::optional<ScaledBoostInt128>>(index).value()};
-#endif
-					}
-					if constexpr (variantContainsV<std::int16_t, V>)
-						return V{get<std::optional<std::int16_t>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::INT32:
-					if (descriptor.scale != 0)
-					{
-						// For scaled numbers, prefer exact scaled type, then larger scaled types
-						if constexpr (variantContainsV<ScaledInt32, V>)
-							return V{get<std::optional<ScaledInt32>>(index).value()};
-						if constexpr (variantContainsV<ScaledInt64, V>)
-							return V{get<std::optional<ScaledInt64>>(index).value()};
-#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
-						if constexpr (variantContainsV<ScaledBoostInt128, V>)
-							return V{get<std::optional<ScaledBoostInt128>>(index).value()};
-#endif
-					}
-					if constexpr (variantContainsV<std::int32_t, V>)
-						return V{get<std::optional<std::int32_t>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::INT64:
-					if (descriptor.scale != 0)
-					{
-						// For scaled numbers, prefer exact scaled type, then larger scaled types
-						if constexpr (variantContainsV<ScaledInt64, V>)
-							return V{get<std::optional<ScaledInt64>>(index).value()};
-#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
-						if constexpr (variantContainsV<ScaledBoostInt128, V>)
-							return V{get<std::optional<ScaledBoostInt128>>(index).value()};
-#endif
-					}
-					if constexpr (variantContainsV<std::int64_t, V>)
-						return V{get<std::optional<std::int64_t>>(index).value()};
-					break;
-
-#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
-				case DescriptorAdjustedType::INT128:
-					// Prefer opaque (native Firebird) types first
-					if constexpr (variantContainsV<ScaledOpaqueInt128, V>)
-						return V{get<std::optional<ScaledOpaqueInt128>>(index).value()};
-					else if (descriptor.scale != 0)
-					{
-						if constexpr (variantContainsV<ScaledBoostInt128, V>)
-							return V{get<std::optional<ScaledBoostInt128>>(index).value()};
-					}
-					else if constexpr (variantContainsV<BoostInt128, V>)
-						return V{get<std::optional<BoostInt128>>(index).value()};
-					break;
-#endif
-
-				case DescriptorAdjustedType::FLOAT:
-					if constexpr (variantContainsV<float, V>)
-						return V{get<std::optional<float>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::DOUBLE:
-					if constexpr (variantContainsV<double, V>)
-						return V{get<std::optional<double>>(index).value()};
-					break;
-
-#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
-				case DescriptorAdjustedType::DECFLOAT16:
-					// Prefer opaque (native Firebird) types first
-					if constexpr (variantContainsV<OpaqueDecFloat16, V>)
-						return V{get<std::optional<OpaqueDecFloat16>>(index).value()};
-					else if constexpr (variantContainsV<BoostDecFloat16, V>)
-						return V{get<std::optional<BoostDecFloat16>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::DECFLOAT34:
-					// Prefer opaque (native Firebird) types first
-					if constexpr (variantContainsV<OpaqueDecFloat34, V>)
-						return V{get<std::optional<OpaqueDecFloat34>>(index).value()};
-					else if constexpr (variantContainsV<BoostDecFloat34, V>)
-						return V{get<std::optional<BoostDecFloat34>>(index).value()};
-					break;
-#endif
-
-				case DescriptorAdjustedType::STRING:
-					if constexpr (variantContainsV<std::string, V>)
-						return V{get<std::optional<std::string>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::DATE:
-					// Prefer opaque (native Firebird) types first
-					if constexpr (variantContainsV<OpaqueDate, V>)
-						return V{get<std::optional<OpaqueDate>>(index).value()};
-					else if constexpr (variantContainsV<Date, V>)
-						return V{get<std::optional<Date>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::TIME:
-					// Prefer opaque (native Firebird) types first
-					if constexpr (variantContainsV<OpaqueTime, V>)
-						return V{get<std::optional<OpaqueTime>>(index).value()};
-					else if constexpr (variantContainsV<Time, V>)
-						return V{get<std::optional<Time>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::TIMESTAMP:
-					// Prefer opaque (native Firebird) types first
-					if constexpr (variantContainsV<OpaqueTimestamp, V>)
-						return V{get<std::optional<OpaqueTimestamp>>(index).value()};
-					else if constexpr (variantContainsV<Timestamp, V>)
-						return V{get<std::optional<Timestamp>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::TIME_TZ:
-					// Prefer opaque (native Firebird) types first
-					if constexpr (variantContainsV<OpaqueTimeTz, V>)
-						return V{get<std::optional<OpaqueTimeTz>>(index).value()};
-					else if constexpr (variantContainsV<TimeTz, V>)
-						return V{get<std::optional<TimeTz>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::TIMESTAMP_TZ:
-					// Prefer opaque (native Firebird) types first
-					if constexpr (variantContainsV<OpaqueTimestampTz, V>)
-						return V{get<std::optional<OpaqueTimestampTz>>(index).value()};
-					else if constexpr (variantContainsV<TimestampTz, V>)
-						return V{get<std::optional<TimestampTz>>(index).value()};
-					break;
-
-				case DescriptorAdjustedType::BLOB:
-					if constexpr (variantContainsV<BlobId, V>)
-						return V{get<std::optional<BlobId>>(index).value()};
-					break;
-
-				default:
-					break;
-			}
-
-			// No exact match found, try variant alternatives in declaration order
-			return tryVariantAlternatives<V, 0>(index, descriptor);
-		}
-
-		///
-		/// @brief Recursively tries variant alternatives for type conversion.
-		///
-		template <typename V, std::size_t I = 0>
-		V tryVariantAlternatives(unsigned index, [[maybe_unused]] const Descriptor& descriptor)
-		{
-			using namespace impl::reflection;
-
-			if constexpr (I >= std::variant_size_v<V>)
-			{
-				throw FbCppException(
-					"Cannot convert SQL type to any variant alternative at index " + std::to_string(index));
-			}
-			else
-			{
-				using Alt = std::variant_alternative_t<I, V>;
-
-				if constexpr (std::is_same_v<Alt, std::monostate>)
-				{
-					// Skip monostate in non-null case
-					return tryVariantAlternatives<V, I + 1>(index, descriptor);
-				}
-				else if constexpr (isOpaqueTypeV<Alt>)
-				{
-					// Skip opaque types - they only match exact SQL types, no conversions
-					return tryVariantAlternatives<V, I + 1>(index, descriptor);
-				}
-				else
-				{
-					// Try this alternative - get<T> will throw if conversion fails
-					auto opt = get<std::optional<Alt>>(index);
-					return V{std::move(opt.value())};
-				}
-			}
 		}
 
 		///
@@ -2709,58 +2118,6 @@ namespace fbcpp
 			*reinterpret_cast<std::int16_t*>(&message[descriptor.nullOffset]) = FB_FALSE;
 		}
 
-		// FIXME: floating to integral
-		///
-		/// @brief Reads numeric column data, performing conversion to the desired type.
-		///
-		template <typename T>
-		std::optional<T> getNumber(unsigned index, std::optional<int>& scale, const char* typeName)
-		{
-			assert(isValid());
-
-			const auto& descriptor = getOutDescriptor(index);
-			const auto* const message = outMessage.data();
-
-			if (*reinterpret_cast<const std::int16_t*>(&message[descriptor.nullOffset]) != FB_FALSE)
-				return std::nullopt;
-
-			auto data = &message[descriptor.offset];
-#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
-			std::optional<BoostInt128> boostInt128;
-			std::optional<BoostDecFloat16> boostDecFloat16;
-			std::optional<BoostDecFloat34> boostDecFloat34;
-#endif
-
-			// FIXME: Use IUtil
-			switch (descriptor.adjustedType)
-			{
-#if FB_CPP_USE_BOOST_MULTIPRECISION != 0
-				case DescriptorAdjustedType::INT128:
-					boostInt128.emplace(
-						numericConverter.opaqueInt128ToBoostInt128(*reinterpret_cast<const OpaqueInt128*>(data)));
-					data = reinterpret_cast<const std::byte*>(&boostInt128.value());
-					break;
-
-				case DescriptorAdjustedType::DECFLOAT16:
-					boostDecFloat16.emplace(numericConverter.opaqueDecFloat16ToBoostDecFloat16(
-						*reinterpret_cast<const OpaqueDecFloat16*>(data)));
-					data = reinterpret_cast<const std::byte*>(&boostDecFloat16.value());
-					break;
-
-				case DescriptorAdjustedType::DECFLOAT34:
-					boostDecFloat34.emplace(numericConverter.opaqueDecFloat34ToBoostDecFloat34(
-						*reinterpret_cast<const OpaqueDecFloat34*>(data)));
-					data = reinterpret_cast<const std::byte*>(&boostDecFloat34.value());
-					break;
-#endif
-
-				default:
-					break;
-			}
-
-			return convertNumber<T>(descriptor, data, scale, typeName);
-		}
-
 		[[noreturn]] static void throwInvalidType(const char* actualType, DescriptorAdjustedType descriptorType)
 		{
 			throw FbCppException("Invalid type: actual type " + std::string(actualType) + ", descriptor type " +
@@ -2845,6 +2202,7 @@ namespace fbcpp
 		FbRef<fb::IMessageMetadata> outMetadata;
 		std::vector<Descriptor> outDescriptors;
 		std::vector<std::byte> outMessage;
+		Row outRow;
 		StatementType type;
 		unsigned cursorFlags = 0;
 	};

--- a/src/fb-cpp/Transaction.cpp
+++ b/src/fb-cpp/Transaction.cpp
@@ -139,8 +139,7 @@ Transaction::Transaction(Attachment& attachment, const TransactionOptions& optio
 
 	const auto master = client.getMaster();
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	auto tpbBuilder = buildTpb(master, statusWrapper, options);
 	const auto tpbBuffer = tpbBuilder->getBuffer(&statusWrapper);
@@ -154,8 +153,7 @@ Transaction::Transaction(Attachment& attachment, std::string_view setTransaction
 {
 	assert(attachment.isValid());
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	handle.reset(
 		attachment.getHandle()->execute(&statusWrapper, nullptr, static_cast<unsigned>(setTransactionCmd.length()),
@@ -179,8 +177,7 @@ Transaction::Transaction(std::span<std::reference_wrapper<Attachment>> attachmen
 
 	const auto master = client.getMaster();
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	auto tpbBuilder = buildTpb(master, statusWrapper, options);
 	const auto tpbBuffer = tpbBuilder->getBuffer(&statusWrapper);
@@ -203,8 +200,7 @@ void Transaction::rollback()
 	assert(isValid());
 	assert(state == TransactionState::ACTIVE || state == TransactionState::PREPARED);
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	handle->rollback(&statusWrapper);
 	handle.reset();
@@ -216,8 +212,7 @@ void Transaction::commit()
 	assert(isValid());
 	assert(state == TransactionState::ACTIVE || state == TransactionState::PREPARED);
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	handle->commit(&statusWrapper);
 	handle.reset();
@@ -229,8 +224,7 @@ void Transaction::commitRetaining()
 	assert(isValid());
 	assert(state == TransactionState::ACTIVE);
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	handle->commitRetaining(&statusWrapper);
 }
@@ -240,8 +234,7 @@ void Transaction::rollbackRetaining()
 	assert(isValid());
 	assert(state == TransactionState::ACTIVE);
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	handle->rollbackRetaining(&statusWrapper);
 }
@@ -256,8 +249,7 @@ void Transaction::prepare(std::span<const std::uint8_t> message)
 	assert(isValid());
 	assert(state == TransactionState::ACTIVE);
 
-	const auto status = client.newStatus();
-	StatusWrapper statusWrapper{client, status.get()};
+	StatusWrapper statusWrapper{client};
 
 	handle->prepare(&statusWrapper, static_cast<unsigned>(message.size()), message.data());
 	state = TransactionState::PREPARED;

--- a/src/test/Batch.cpp
+++ b/src/test/Batch.cpp
@@ -124,8 +124,7 @@ BOOST_AUTO_TEST_CASE(constructorFromAttachmentAndExecute)
 		// Get metadata to build raw messages.
 		auto metadata = batch.getInputMetadata();
 
-		FbUniquePtr<fb::IStatus> tempStatus{CLIENT.newStatus()};
-		impl::StatusWrapper tempWrapper{CLIENT, tempStatus.get()};
+		impl::StatusWrapper tempWrapper{CLIENT};
 		const auto msgLength = metadata->getMessageLength(&tempWrapper);
 		const auto idOffset = metadata->getOffset(&tempWrapper, 0);
 		const auto idNullOffset = metadata->getNullOffset(&tempWrapper, 0);

--- a/src/test/CalendarConverter.cpp
+++ b/src/test/CalendarConverter.cpp
@@ -109,8 +109,7 @@ static const std::initializer_list<DateCase> DATE_CASES{
 
 BOOST_DATA_TEST_CASE(dateConversion, data::make(DATE_CASES), dateCase)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::CalendarConverter converter{CLIENT, &statusWrapper};
 
@@ -138,8 +137,7 @@ static const std::initializer_list<TimeCase> TIME_CASES{
 
 BOOST_DATA_TEST_CASE(timeConversion, data::make(TIME_CASES), timeCase)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::CalendarConverter converter{CLIENT, &statusWrapper};
 
@@ -168,8 +166,7 @@ static const std::initializer_list<TimestampCase> TIMESTAMP_CASES{
 
 BOOST_DATA_TEST_CASE(timestampConversion, data::make(TIMESTAMP_CASES), timestampCase)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::CalendarConverter converter{CLIENT, &statusWrapper};
 
@@ -198,8 +195,7 @@ static const std::initializer_list<TimeTzCase> TIME_TZ_CASES{
 
 BOOST_DATA_TEST_CASE(timeTzConversion, data::make(TIME_TZ_CASES), timeTzCase)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::CalendarConverter converter{CLIENT, &statusWrapper};
 
@@ -227,8 +223,7 @@ static const std::initializer_list<TimeTzOffsetCase> TIME_TZ_OFFSET_CASES{
 
 BOOST_DATA_TEST_CASE(timeTzOffsetConversion, data::make(TIME_TZ_OFFSET_CASES), timeTzOffsetCase)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::CalendarConverter converter{CLIENT, &statusWrapper};
 
@@ -252,8 +247,7 @@ static const std::initializer_list<TimestampTzCase> TIMESTAMP_TZ_CASES{
 
 BOOST_DATA_TEST_CASE(timestampTzConversion, data::make(TIMESTAMP_TZ_CASES), timestampTzCase)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::CalendarConverter converter{CLIENT, &statusWrapper};
 
@@ -281,8 +275,7 @@ static const std::initializer_list<TimestampTzOffsetCase> TIMESTAMP_TZ_OFFSET_CA
 
 BOOST_DATA_TEST_CASE(timestampTzOffsetConversion, data::make(TIMESTAMP_TZ_OFFSET_CASES), timestampTzOffsetCase)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::CalendarConverter converter{CLIENT, &statusWrapper};
 

--- a/src/test/CalendarConverter.cpp
+++ b/src/test/CalendarConverter.cpp
@@ -109,9 +109,7 @@ static const std::initializer_list<DateCase> DATE_CASES{
 
 BOOST_DATA_TEST_CASE(dateConversion, data::make(DATE_CASES), dateCase)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::CalendarConverter converter{CLIENT, &statusWrapper};
+	impl::CalendarConverter converter{CLIENT};
 
 	const auto& date = dateCase.date;
 	const std::string outputText{dateCase.outputText};
@@ -137,9 +135,7 @@ static const std::initializer_list<TimeCase> TIME_CASES{
 
 BOOST_DATA_TEST_CASE(timeConversion, data::make(TIME_CASES), timeCase)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::CalendarConverter converter{CLIENT, &statusWrapper};
+	impl::CalendarConverter converter{CLIENT};
 
 	const Time time{timeCase.time};
 	const std::string outputText{timeCase.outputText};
@@ -166,9 +162,7 @@ static const std::initializer_list<TimestampCase> TIMESTAMP_CASES{
 
 BOOST_DATA_TEST_CASE(timestampConversion, data::make(TIMESTAMP_CASES), timestampCase)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::CalendarConverter converter{CLIENT, &statusWrapper};
+	impl::CalendarConverter converter{CLIENT};
 
 	const auto timestamp = timestampCase.timestamp;
 	const std::string outputText{timestampCase.outputText};
@@ -197,21 +191,21 @@ BOOST_DATA_TEST_CASE(timeTzConversion, data::make(TIME_TZ_CASES), timeTzCase)
 {
 	impl::StatusWrapper statusWrapper{CLIENT};
 
-	impl::CalendarConverter converter{CLIENT, &statusWrapper};
+	impl::CalendarConverter converter{CLIENT};
 
 	const TimeTz& timeTz = timeTzCase.timeTz;
 	const std::string outputText{timeTzCase.outputText};
 	const std::string inputText{timeTzCase.inputText.value_or(outputText)};
 
-	const auto opaque = converter.timeTzToOpaqueTimeTz(timeTz);
-	BOOST_CHECK(converter.opaqueTimeTzToTimeTz(opaque) == timeTz);
-	BOOST_CHECK_EQUAL(converter.opaqueTimeTzToString(opaque), outputText);
+	const auto opaque = converter.timeTzToOpaqueTimeTz(&statusWrapper, timeTz);
+	BOOST_CHECK(converter.opaqueTimeTzToTimeTz(&statusWrapper, opaque) == timeTz);
+	BOOST_CHECK_EQUAL(converter.opaqueTimeTzToString(&statusWrapper, opaque), outputText);
 
-	const auto parsed = converter.stringToTimeTz(inputText);
+	const auto parsed = converter.stringToTimeTz(&statusWrapper, inputText);
 	BOOST_CHECK(parsed == timeTz);
 
-	const auto parsedOpaque = converter.stringToOpaqueTimeTz(inputText);
-	BOOST_CHECK(converter.opaqueTimeTzToTimeTz(parsedOpaque) == timeTz);
+	const auto parsedOpaque = converter.stringToOpaqueTimeTz(&statusWrapper, inputText);
+	BOOST_CHECK(converter.opaqueTimeTzToTimeTz(&statusWrapper, parsedOpaque) == timeTz);
 }
 
 
@@ -225,13 +219,13 @@ BOOST_DATA_TEST_CASE(timeTzOffsetConversion, data::make(TIME_TZ_OFFSET_CASES), t
 {
 	impl::StatusWrapper statusWrapper{CLIENT};
 
-	impl::CalendarConverter converter{CLIENT, &statusWrapper};
+	impl::CalendarConverter converter{CLIENT};
 
 	const std::string outputText{timeTzOffsetCase.outputText};
 	const std::string inputText{timeTzOffsetCase.inputText.value_or(outputText)};
 
-	const auto parsedOpaque = converter.stringToOpaqueTimeTz(inputText);
-	const auto text = converter.opaqueTimeTzToString(parsedOpaque);
+	const auto parsedOpaque = converter.stringToOpaqueTimeTz(&statusWrapper, inputText);
+	const auto text = converter.opaqueTimeTzToString(&statusWrapper, parsedOpaque);
 	BOOST_CHECK_EQUAL(text, inputText);
 }
 
@@ -249,21 +243,21 @@ BOOST_DATA_TEST_CASE(timestampTzConversion, data::make(TIMESTAMP_TZ_CASES), time
 {
 	impl::StatusWrapper statusWrapper{CLIENT};
 
-	impl::CalendarConverter converter{CLIENT, &statusWrapper};
+	impl::CalendarConverter converter{CLIENT};
 
 	const TimestampTz& timestampTz = timestampTzCase.timestampTz;
 	const std::string outputText{timestampTzCase.outputText};
 	const std::string inputText{timestampTzCase.inputText.value_or(outputText)};
 
-	const auto opaque = converter.timestampTzToOpaqueTimestampTz(timestampTz);
-	BOOST_CHECK(converter.opaqueTimestampTzToTimestampTz(opaque) == timestampTz);
-	BOOST_CHECK_EQUAL(converter.opaqueTimestampTzToString(opaque), outputText);
+	const auto opaque = converter.timestampTzToOpaqueTimestampTz(&statusWrapper, timestampTz);
+	BOOST_CHECK(converter.opaqueTimestampTzToTimestampTz(&statusWrapper, opaque) == timestampTz);
+	BOOST_CHECK_EQUAL(converter.opaqueTimestampTzToString(&statusWrapper, opaque), outputText);
 
-	const auto parsed = converter.stringToTimestampTz(inputText);
+	const auto parsed = converter.stringToTimestampTz(&statusWrapper, inputText);
 	BOOST_CHECK(parsed == timestampTz);
 
-	const auto parsedOpaque = converter.stringToOpaqueTimestampTz(inputText);
-	BOOST_CHECK(converter.opaqueTimestampTzToTimestampTz(parsedOpaque) == timestampTz);
+	const auto parsedOpaque = converter.stringToOpaqueTimestampTz(&statusWrapper, inputText);
+	BOOST_CHECK(converter.opaqueTimestampTzToTimestampTz(&statusWrapper, parsedOpaque) == timestampTz);
 }
 
 
@@ -277,13 +271,13 @@ BOOST_DATA_TEST_CASE(timestampTzOffsetConversion, data::make(TIMESTAMP_TZ_OFFSET
 {
 	impl::StatusWrapper statusWrapper{CLIENT};
 
-	impl::CalendarConverter converter{CLIENT, &statusWrapper};
+	impl::CalendarConverter converter{CLIENT};
 
 	const std::string outputText{timestampTzOffsetCase.outputText};
 	const std::string inputText{timestampTzOffsetCase.inputText.value_or(outputText)};
 
-	const auto parsedOpaque = converter.stringToOpaqueTimestampTz(inputText);
-	const auto text = converter.opaqueTimestampTzToString(parsedOpaque);
+	const auto parsedOpaque = converter.stringToOpaqueTimestampTz(&statusWrapper, inputText);
+	const auto text = converter.opaqueTimestampTzToString(&statusWrapper, parsedOpaque);
 	BOOST_CHECK_EQUAL(text, inputText);
 }
 

--- a/src/test/NumericConverter.cpp
+++ b/src/test/NumericConverter.cpp
@@ -42,9 +42,7 @@ BOOST_AUTO_TEST_SUITE(NumericConverterSuite)
 
 BOOST_AUTO_TEST_CASE(convertScaledInt16)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(ScaledInt16{12'3, -1}, -2), 12'30);
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(ScaledInt16{-12'3, -1}, -2), -12'30);
@@ -144,9 +142,7 @@ BOOST_AUTO_TEST_CASE(convertScaledInt16)
 
 BOOST_AUTO_TEST_CASE(convertScaledInt32)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	BOOST_CHECK_THROW(converter.numberToNumber<std::int16_t>(ScaledInt32{12'3, -1}, -4), FbCppException);
 	BOOST_CHECK_THROW(converter.numberToNumber<std::int16_t>(ScaledInt32{214'748'364'7, -1}, -1), FbCppException);
@@ -243,9 +239,7 @@ BOOST_AUTO_TEST_CASE(convertScaledInt32)
 
 BOOST_AUTO_TEST_CASE(convertScaledInt64)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	BOOST_CHECK_THROW(
 		converter.numberToNumber<std::int32_t>(ScaledInt64{922'337'203'685'477'580'7LL, -1}, -1), FbCppException);
@@ -352,9 +346,7 @@ BOOST_AUTO_TEST_CASE(convertScaledInt64)
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
 BOOST_AUTO_TEST_CASE(convertScaledBoostInt128)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	BOOST_CHECK_THROW(converter.numberToNumber<std::int64_t>(
 						  ScaledBoostInt128{BoostInt128{"170141183460469231731687303715884105727"}, -1}, -1),
@@ -479,9 +471,7 @@ BOOST_AUTO_TEST_CASE(convertScaledBoostInt128)
 
 BOOST_AUTO_TEST_CASE(convertFloat)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(12.3f, -2), 12'30);
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(-12.3f, -2), -12'30);
@@ -562,9 +552,7 @@ BOOST_AUTO_TEST_CASE(convertFloat)
 
 BOOST_AUTO_TEST_CASE(convertDouble)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(12.3, -2), 12'30);
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(-12.3, -2), -12'30);
@@ -647,9 +635,7 @@ BOOST_AUTO_TEST_CASE(convertDouble)
 
 BOOST_AUTO_TEST_CASE(convertDecFloat16)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(BoostDecFloat16{"12.3"}, -2), 12'30);
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(BoostDecFloat16{"-12.3"}, -2), -12'30);
@@ -732,9 +718,7 @@ BOOST_AUTO_TEST_CASE(convertDecFloat16)
 
 BOOST_AUTO_TEST_CASE(convertDecFloat34)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(BoostDecFloat34{"12.3"}, -2), 12'30);
 	BOOST_CHECK_EQUAL(converter.numberToNumber<std::int16_t>(BoostDecFloat34{"-12.3"}, -2), -12'30);
@@ -819,7 +803,7 @@ BOOST_AUTO_TEST_CASE(decFloat16NumberLimits)
 {
 	impl::StatusWrapper statusWrapper{CLIENT};
 
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	const auto maxValue = std::numeric_limits<BoostDecFloat16>::max();
 	const auto minValue = std::numeric_limits<BoostDecFloat16>::min();
@@ -846,7 +830,7 @@ BOOST_AUTO_TEST_CASE(decFloat34NumberLimits)
 {
 	impl::StatusWrapper statusWrapper{CLIENT};
 
-	impl::NumericConverter converter{CLIENT, &statusWrapper};
+	impl::NumericConverter converter{CLIENT};
 
 	const auto maxValue = std::numeric_limits<BoostDecFloat34>::max();
 	const auto minValue = std::numeric_limits<BoostDecFloat34>::min();

--- a/src/test/NumericConverter.cpp
+++ b/src/test/NumericConverter.cpp
@@ -801,8 +801,6 @@ BOOST_AUTO_TEST_CASE(convertDecFloat34)
 
 BOOST_AUTO_TEST_CASE(decFloat16NumberLimits)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
 	impl::NumericConverter converter{CLIENT};
 
 	const auto maxValue = std::numeric_limits<BoostDecFloat16>::max();
@@ -828,8 +826,6 @@ BOOST_AUTO_TEST_CASE(decFloat16NumberLimits)
 
 BOOST_AUTO_TEST_CASE(decFloat34NumberLimits)
 {
-	impl::StatusWrapper statusWrapper{CLIENT};
-
 	impl::NumericConverter converter{CLIENT};
 
 	const auto maxValue = std::numeric_limits<BoostDecFloat34>::max();

--- a/src/test/NumericConverter.cpp
+++ b/src/test/NumericConverter.cpp
@@ -42,8 +42,7 @@ BOOST_AUTO_TEST_SUITE(NumericConverterSuite)
 
 BOOST_AUTO_TEST_CASE(convertScaledInt16)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -145,8 +144,7 @@ BOOST_AUTO_TEST_CASE(convertScaledInt16)
 
 BOOST_AUTO_TEST_CASE(convertScaledInt32)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -245,8 +243,7 @@ BOOST_AUTO_TEST_CASE(convertScaledInt32)
 
 BOOST_AUTO_TEST_CASE(convertScaledInt64)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -355,8 +352,7 @@ BOOST_AUTO_TEST_CASE(convertScaledInt64)
 #if FB_CPP_USE_BOOST_MULTIPRECISION != 0
 BOOST_AUTO_TEST_CASE(convertScaledBoostInt128)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -483,8 +479,7 @@ BOOST_AUTO_TEST_CASE(convertScaledBoostInt128)
 
 BOOST_AUTO_TEST_CASE(convertFloat)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -567,8 +562,7 @@ BOOST_AUTO_TEST_CASE(convertFloat)
 
 BOOST_AUTO_TEST_CASE(convertDouble)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -653,8 +647,7 @@ BOOST_AUTO_TEST_CASE(convertDouble)
 
 BOOST_AUTO_TEST_CASE(convertDecFloat16)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -739,8 +732,7 @@ BOOST_AUTO_TEST_CASE(convertDecFloat16)
 
 BOOST_AUTO_TEST_CASE(convertDecFloat34)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -825,8 +817,7 @@ BOOST_AUTO_TEST_CASE(convertDecFloat34)
 
 BOOST_AUTO_TEST_CASE(decFloat16NumberLimits)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 
@@ -853,8 +844,7 @@ BOOST_AUTO_TEST_CASE(decFloat16NumberLimits)
 
 BOOST_AUTO_TEST_CASE(decFloat34NumberLimits)
 {
-	const auto status = CLIENT.newStatus();
-	impl::StatusWrapper statusWrapper{CLIENT, status.get()};
+	impl::StatusWrapper statusWrapper{CLIENT};
 
 	impl::NumericConverter converter{CLIENT, &statusWrapper};
 

--- a/src/test/RowSet.cpp
+++ b/src/test/RowSet.cpp
@@ -1,0 +1,218 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 F.D.Castel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "TestUtil.h"
+#include "fb-cpp/RowSet.h"
+#include "fb-cpp/Statement.h"
+#include "fb-cpp/Transaction.h"
+
+
+BOOST_AUTO_TEST_SUITE(RowSetSuite)
+
+BOOST_AUTO_TEST_CASE(fetchRowsIntoRowSet)
+{
+	const auto database = getTempFile("RowSet-fetchRowsIntoRowSet.fdb");
+
+	Attachment attachment{CLIENT, database, AttachmentOptions().setCreateDatabase(true)};
+	FbDropDatabase attachmentDrop{attachment};
+
+	Transaction transaction{attachment};
+
+	Statement ddl{attachment, transaction, "create table t (col integer)"};
+	ddl.execute(transaction);
+	transaction.commitRetaining();
+
+	Statement insert{attachment, transaction, "insert into t (col) values (?)"};
+	for (int i = 1; i <= 5; ++i)
+	{
+		insert.setInt32(0, i);
+		insert.execute(transaction);
+	}
+
+	Statement select{attachment, transaction, "select col from t order by col"};
+	BOOST_REQUIRE(select.execute(transaction));
+
+	// The first row (1) was fetched by execute(). Fetch remaining rows into RowSet.
+	RowSet rowSet{select, 10};
+
+	BOOST_CHECK_EQUAL(rowSet.getCount(), 4u);
+	BOOST_CHECK(rowSet.getMessageLength() > 0);
+	BOOST_CHECK_EQUAL(
+		rowSet.getRawBuffer().size(), static_cast<std::size_t>(rowSet.getCount()) * rowSet.getMessageLength());
+
+	// Verify row data using typed Row access.
+	for (unsigned i = 0; i < rowSet.getCount(); ++i)
+	{
+		auto row = rowSet.getRow(i);
+		BOOST_CHECK_EQUAL(row.getInt32(0).value(), static_cast<std::int32_t>(i + 2));
+	}
+}
+
+BOOST_AUTO_TEST_CASE(fetchFewerRowsThanMaxRows)
+{
+	const auto database = getTempFile("RowSet-fetchFewerRowsThanMaxRows.fdb");
+
+	Attachment attachment{CLIENT, database, AttachmentOptions().setCreateDatabase(true)};
+	FbDropDatabase attachmentDrop{attachment};
+
+	Transaction transaction{attachment};
+
+	Statement ddl{attachment, transaction, "create table t (col integer)"};
+	ddl.execute(transaction);
+	transaction.commitRetaining();
+
+	Statement insert{attachment, transaction, "insert into t (col) values (?)"};
+	for (int i = 1; i <= 3; ++i)
+	{
+		insert.setInt32(0, i);
+		insert.execute(transaction);
+	}
+
+	Statement select{attachment, transaction, "select col from t order by col"};
+	BOOST_REQUIRE(select.execute(transaction));
+
+	// execute() fetched row 1. Request 100 rows but only 2 remain.
+	RowSet rowSet{select, 100};
+
+	BOOST_CHECK_EQUAL(rowSet.getCount(), 2u);
+	BOOST_CHECK_EQUAL(
+		rowSet.getRawBuffer().size(), static_cast<std::size_t>(rowSet.getCount()) * rowSet.getMessageLength());
+}
+
+BOOST_AUTO_TEST_CASE(rowSetIsDisconnectedFromStatement)
+{
+	const auto database = getTempFile("RowSet-isDisconnectedFromStatement.fdb");
+
+	Attachment attachment{CLIENT, database, AttachmentOptions().setCreateDatabase(true)};
+	FbDropDatabase attachmentDrop{attachment};
+
+	Transaction transaction{attachment};
+
+	Statement ddl{attachment, transaction, "create table t (col integer)"};
+	ddl.execute(transaction);
+	transaction.commitRetaining();
+
+	Statement insert{attachment, transaction, "insert into t (col) values (?)"};
+	for (int i = 1; i <= 3; ++i)
+	{
+		insert.setInt32(0, i);
+		insert.execute(transaction);
+	}
+
+	Statement select{attachment, transaction, "select col from t order by col"};
+	BOOST_REQUIRE(select.execute(transaction));
+
+	RowSet rowSet{select, 10};
+	BOOST_CHECK_EQUAL(rowSet.getCount(), 2u);
+
+	// Free the statement; the RowSet data is still valid.
+	select.free();
+
+	BOOST_CHECK(!rowSet.getRawBuffer().empty());
+	BOOST_CHECK_EQUAL(rowSet.getCount(), 2u);
+
+	// Typed access still works after the statement is freed.
+	BOOST_CHECK_EQUAL(rowSet.getRow(0).getInt32(0).value(), 2);
+	BOOST_CHECK_EQUAL(rowSet.getRow(1).getInt32(0).value(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(moveConstructor)
+{
+	const auto database = getTempFile("RowSet-moveConstructor.fdb");
+
+	Attachment attachment{CLIENT, database, AttachmentOptions().setCreateDatabase(true)};
+	FbDropDatabase attachmentDrop{attachment};
+
+	Transaction transaction{attachment};
+
+	Statement ddl{attachment, transaction, "create table t (col integer)"};
+	ddl.execute(transaction);
+	transaction.commitRetaining();
+
+	Statement insert{attachment, transaction, "insert into t (col) values (?)"};
+	for (int i = 1; i <= 3; ++i)
+	{
+		insert.setInt32(0, i);
+		insert.execute(transaction);
+	}
+
+	Statement select{attachment, transaction, "select col from t order by col"};
+	BOOST_REQUIRE(select.execute(transaction));
+
+	RowSet rowSet1{select, 10};
+	const auto count = rowSet1.getCount();
+
+	RowSet rowSet2{std::move(rowSet1)};
+	BOOST_CHECK_EQUAL(rowSet2.getCount(), count);
+	BOOST_CHECK_EQUAL(rowSet1.getCount(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(fetchMultipleBatchesFromSameStatement)
+{
+	const auto database = getTempFile("RowSet-fetchMultipleBatches.fdb");
+
+	Attachment attachment{CLIENT, database, AttachmentOptions().setCreateDatabase(true)};
+	FbDropDatabase attachmentDrop{attachment};
+
+	Transaction transaction{attachment};
+
+	Statement ddl{attachment, transaction, "create table t (col integer)"};
+	ddl.execute(transaction);
+	transaction.commitRetaining();
+
+	Statement insert{attachment, transaction, "insert into t (col) values (?)"};
+	for (int i = 1; i <= 10; ++i)
+	{
+		insert.setInt32(0, i);
+		insert.execute(transaction);
+	}
+
+	Statement select{attachment, transaction, "select col from t order by col"};
+	BOOST_REQUIRE(select.execute(transaction));
+
+	// execute() fetched row 1. Fetch batches of 3 from the remaining 9 rows.
+	RowSet batch1{select, 3};
+	BOOST_CHECK_EQUAL(batch1.getCount(), 3u);
+	BOOST_CHECK_EQUAL(batch1.getRow(0).getInt32(0).value(), 2);
+	BOOST_CHECK_EQUAL(batch1.getRow(1).getInt32(0).value(), 3);
+	BOOST_CHECK_EQUAL(batch1.getRow(2).getInt32(0).value(), 4);
+
+	RowSet batch2{select, 3};
+	BOOST_CHECK_EQUAL(batch2.getCount(), 3u);
+	BOOST_CHECK_EQUAL(batch2.getRow(0).getInt32(0).value(), 5);
+	BOOST_CHECK_EQUAL(batch2.getRow(1).getInt32(0).value(), 6);
+	BOOST_CHECK_EQUAL(batch2.getRow(2).getInt32(0).value(), 7);
+
+	RowSet batch3{select, 3};
+	BOOST_CHECK_EQUAL(batch3.getCount(), 3u);
+	BOOST_CHECK_EQUAL(batch3.getRow(0).getInt32(0).value(), 8);
+	BOOST_CHECK_EQUAL(batch3.getRow(1).getInt32(0).value(), 9);
+	BOOST_CHECK_EQUAL(batch3.getRow(2).getInt32(0).value(), 10);
+
+	// No more rows; the next batch should be empty.
+	RowSet batch4{select, 3};
+	BOOST_CHECK_EQUAL(batch4.getCount(), 0u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/RowSet.cpp
+++ b/src/test/RowSet.cpp
@@ -166,6 +166,51 @@ BOOST_AUTO_TEST_CASE(moveConstructor)
 	RowSet rowSet2{std::move(rowSet1)};
 	BOOST_CHECK_EQUAL(rowSet2.getCount(), count);
 	BOOST_CHECK_EQUAL(rowSet1.getCount(), 0u);
+
+	// Typed access works on the moved-to RowSet.
+	BOOST_CHECK_EQUAL(rowSet2.getRow(0).getInt32(0).value(), 2);
+	BOOST_CHECK_EQUAL(rowSet2.getRow(1).getInt32(0).value(), 3);
+}
+
+BOOST_AUTO_TEST_CASE(moveAssignment)
+{
+	const auto database = getTempFile("RowSet-moveAssignment.fdb");
+
+	Attachment attachment{CLIENT, database, AttachmentOptions().setCreateDatabase(true)};
+	FbDropDatabase attachmentDrop{attachment};
+
+	Transaction transaction{attachment};
+
+	Statement ddl{attachment, transaction, "create table t (col integer)"};
+	ddl.execute(transaction);
+	transaction.commitRetaining();
+
+	Statement insert{attachment, transaction, "insert into t (col) values (?)"};
+	for (int i = 1; i <= 5; ++i)
+	{
+		insert.setInt32(0, i);
+		insert.execute(transaction);
+	}
+
+	Statement select{attachment, transaction, "select col from t order by col"};
+	BOOST_REQUIRE(select.execute(transaction));
+
+	// Fetch rows 2-3 into first batch, rows 4-5 into second.
+	RowSet rowSet1{select, 2};
+	RowSet rowSet2{select, 2};
+
+	BOOST_CHECK_EQUAL(rowSet1.getCount(), 2u);
+	BOOST_CHECK_EQUAL(rowSet1.getRow(0).getInt32(0).value(), 2);
+	BOOST_CHECK_EQUAL(rowSet2.getCount(), 2u);
+	BOOST_CHECK_EQUAL(rowSet2.getRow(0).getInt32(0).value(), 4);
+
+	// Move-assign rowSet2 into rowSet1 (overwrites old data).
+	rowSet1 = std::move(rowSet2);
+
+	BOOST_CHECK_EQUAL(rowSet1.getCount(), 2u);
+	BOOST_CHECK_EQUAL(rowSet1.getRow(0).getInt32(0).value(), 4);
+	BOOST_CHECK_EQUAL(rowSet1.getRow(1).getInt32(0).value(), 5);
+	BOOST_CHECK_EQUAL(rowSet2.getCount(), 0u);
 }
 
 BOOST_AUTO_TEST_CASE(fetchMultipleBatchesFromSameStatement)


### PR DESCRIPTION
_Addresses [REQ-3 from #42](https://github.com/asfernandes/fb-cpp/issues/42) per [@asfernandes](https://github.com/asfernandes) [feedback](https://github.com/asfernandes/fb-cpp/issues/42#issuecomment-2714836693)._

The original REQ-3 proposed a `fetchNext(void* buffer)` overload. This approach was rejected and instead requested a "disconnected RowSet (a buffer of rows, disconnected after fetched) class."

The RowSet feature is critical for the ODBC driver's N-row prefetch pattern (`SQL_ATTR_ROW_ARRAY_SIZE > 1`), which eliminates per-row `fetchNext()` + `memcpy` overhead.

After several iterations based on reviewer feedback, the current design introduces two new classes:

- `Row` — a lightweight, non-owning view of a single row's message buffer with typed accessors.
- `RowSet` — a disconnected buffer of rows fetched from a Statement's result set.

`Statement` is refactored to use `Row` internally, eliminating ~700 lines of duplicated reading/conversion logic.

## Design

### Row — lightweight non-owning view

`Row` is a value-type view over a raw message buffer. It holds four pointers: `message`, `descriptors`, `numericConverter`, and `calendarConverter`. All typed read logic (`isNull`, `getBool`, `getInt32`, `getString`, `get<T>`, etc.) lives in `Row`.

`Row` is used in two places:
- **Inside `Statement`** as a private `outRow` member, pointing to the statement's own `outMessage` buffer. All ~30 public getters in `Statement` now delegate to `outRow`. The pointer is stable because `outMessage` is sized once during construction and never reallocated.
- **Inside `RowSet::getRow(i)`** as a transient view over the i-th row in the fetched buffer.

This design satisfies the constraint of eliminating duplicated non-trivial getters while keeping `Row` independent of both `Statement` and `RowSet` as classes.

### RowSet — disconnected row buffer

`RowSet` is a move-only class that:

1. **Fetches at construction time**: Takes a `Statement&` with an open result set and a `maxRows` count. Calls `IResultSet::fetchNext()` directly into a contiguous internal buffer, up to `maxRows` times.
2. **Is disconnected after construction**: Owns all row data, descriptors, and converters independently. The source `Statement` can be freed or reused without affecting the `RowSet`.
3. **Provides both typed and raw access**: `getRow(index)` returns a `Row` for typed column reading. `getRawRow(index)` returns a `std::span<const std::byte>` for zero-copy scenarios.

### API

```cpp
// Lightweight non-owning typed view of a single row
class Row final
{
public:
    Row() = default;
    Row(const std::byte* message, const std::vector<Descriptor>& descriptors,
        NumericConverter& numericConverter, CalendarConverter& calendarConverter);

    bool isNull(unsigned index);
    std::optional<bool> getBool(unsigned index);
    std::optional<std::int32_t> getInt32(unsigned index);
    std::optional<std::string> getString(unsigned index);
    // ... all other typed accessors from Statement ...

    template <typename T> T get(unsigned index);
    template <Aggregate T> T get();
    template <TupleLike T> T get();
    template <VariantLike V> V get(unsigned index);
};

// Disconnected row buffer with typed and raw access
class RowSet final
{
public:
    explicit RowSet(Statement& statement, unsigned maxRows);

    unsigned getCount() const noexcept;
    unsigned getMessageLength() const noexcept;

    Row getRow(unsigned index);                            // typed access
    std::span<const std::byte> getRawRow(unsigned index) const;  // raw access
    const std::vector<std::byte>& getRawBuffer() const noexcept;
};

// Statement: public API unchanged — getters now delegate to private outRow
class Statement
{
    // All existing getters preserved with identical signatures.
    // Internally: assert(isValid()); return outRow.getXxx(index);
private:
    Row outRow;  // new private member, points into outMessage
};
```

### ODBC driver usage (N-row prefetch)

```cpp
Statement select{attachment, transaction, sql, options};
select.execute(transaction);

while (true)
{
    RowSet batch{select, rowArraySize};
    if (batch.getCount() == 0)
        break;

    for (unsigned i = 0; i < batch.getCount(); ++i)
    {
        // Typed access
        auto row = batch.getRow(i);
        auto name = row.getString(0);
        auto age  = row.getInt32(1);

        // Zero-copy raw access for direct ODBC buffer filling
        auto raw = batch.getRawRow(i);
        std::memcpy(odbcRow, raw.data(), raw.size());
    }
}
```

## Impact

- **Statement public API unchanged**: All existing `Statement` getters continue to work identically.
- **No duplication**: All reading/conversion logic lives exclusively in `Row`.
- **Zero-copy N-row prefetch**: `RowSet` eliminates the per-row `fetchNext()` + `memcpy` pattern for the ODBC driver.


